### PR TITLE
AM-2782 CVE-2021-22044 spring-cloud-starter-openfeign upgraded to 2.2…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -468,7 +468,7 @@ dependencies {
     testImplementation('org.springframework.cloud:spring-cloud-contract-wiremock:3.1.2')
     testImplementation group: 'org.springframework.boot', name:'spring-boot-starter-test', version: versions.springBoot
     testImplementation group: 'org.springframework.security',name:'spring-security-test', version: versions.springSecurity
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.5.RELEASE'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.10.RELEASE'
     testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot) {
         exclude group: 'junit', module: 'junit'
     }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -10,7 +10,6 @@
         https://tanzu.vmware.com/security/cve-2022-22978</notes>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2022-22976</cve>
-    <cve>CVE-2021-22044</cve>
    </suppress>
     <suppress>
         <notes>CVE-2022-1471 https://tools.hmcts.net/jira/browse/AM-2728 snakeyaml</notes>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2782
CVE-2021-22044 spring-cloud-starter-openfeign upgraded 2.2.10.RELEASE

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
