### PR TITLE
AM-2786 CVE-2023-20873 spring-cloud-starter-bootstrap upgraded 3.0.6 …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ def versions = [
         serenity       : '2.2.12',
         springBoot     : '2.6.6',
         spring         : '5.3.25',
-        springSecurity : '5.7.5',
+        springSecurity : '5.7.8',
         springHystrix  : '2.1.1.RELEASE',
         swagger2Version: '2.10.5',
         pact_version   : '4.1.41',
@@ -316,7 +316,7 @@ dependencies {
     implementation group: 'org.springframework.security', name:'spring-security-config', version: versions.springSecurity
     implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.0'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.10.RELEASE'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.0.4'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.0.6'
     implementation group: 'org.springframework.hateoas', name: 'spring-hateoas', version: '1.2.2'
     implementation group: 'org.springframework', name: 'spring-core', version: versions.spring
     implementation group: 'org.springframework', name: 'spring-beans', version: versions.spring

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -27,12 +27,4 @@
         <notes>https://tools.hmcts.net/jira/browse/AM-2776 springframework</notes>
         <cve>CVE-2023-20863</cve>
     </suppress>
-    <suppress>
-        <notes>https://tools.hmcts.net/jira/browse/AM-2786 spring boot</notes>
-        <cve>CVE-2023-20873</cve>
-    </suppress>
-    <suppress>
-        <notes>https://tools.hmcts.net/jira/browse/AM-2787 spring security</notes>
-        <cve>CVE-2023-20862</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2786
CVE-2023-20873 Fix spring-cloud-starter-bootstrap upgraded 3.0.6 

https://tools.hmcts.net/jira/browse/AM-2787
CVE-2023-20862 spring security upgraded 5.7.8

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
