### PR TITLE
AM-2790 WA R4 Enabling Flags for Refresh in PROD

### DIFF
--- a/src/main/resources/db/migration/V20230510_2790__AM-2790_WA_R4_enable_IAC_CIVIL_PRIVATELAW_flags_in_PROD.sql
+++ b/src/main/resources/db/migration/V20230510_2790__AM-2790_WA_R4_enable_IAC_CIVIL_PRIVATELAW_flags_in_PROD.sql
@@ -1,0 +1,12 @@
+-- AM-2790: WA R4 Enabling Flags for Refresh
+
+-- enable CIVIL flag for: AM-2730 - Prod Civil role issue - Any user with a team leader role does not inherit the permissions of the staff role that it has responsibility for  
+update flag_config set status='true' where flag_name='civil_wa_1_1' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');
+
+
+-- enable IAC flag for: AM-2732 - CA & TS new role mapping for IAC - CTSC
+update flag_config set status='true' where flag_name='iac_wa_1_2' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');
+
+
+-- enable PRIVATELAW flag for: AM-2755 - Add new worktype for Tribunal Caseworker in Private Law
+update flag_config set status='true' where flag_name='privatelaw_wa_1_1' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [AM-2790](https://tools.hmcts.net/jira/browse/AM-2790) _"WA R4 Enabling Flags for Refresh"_:
 * [AM-2730](https://tools.hmcts.net/jira/browse/AM-2730) _"Prod Civil role issue - Any user with a team leader role does not inherit the permissions of the staff role that it has responsibility for"_
 * [AM-2732](https://tools.hmcts.net/jira/browse/AM-2732) _"CA & TS new role mapping for IAC - CTSC"_
 * [AM-2755](https://tools.hmcts.net/jira/browse/AM-2755) _"Add new worktype for Tribunal Caseworker in Private Law"_

### Change description ###

Enable CIVIL, IAC, PRIVATELAW DB flags for WA R4 refresh:
* enable CIVIL flag for: [AM-2730](https://tools.hmcts.net/jira/browse/AM-2730)
* enable IAC flag for: [AM-2732](https://tools.hmcts.net/jira/browse/AM-2732)
* enable PRIVATELAW flag for: [AM-2755](https://tools.hmcts.net/jira/browse/AM-2755)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
