### PR TITLE
AM-2861: Configure new drool rules for Private Law - Cafcass Cymrus

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/FeatureFlagEnum.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/FeatureFlagEnum.java
@@ -11,7 +11,8 @@ public enum FeatureFlagEnum {
     IAC_WA_1_2("iac_wa_1_2"),
     CIVIL_WA_1_1("civil_wa_1_1"),
     PRIVATELAW_WA_1_1("privatelaw_wa_1_1"),
-    EMPLOYMENT_WA_1_0("employment_wa_1_0");
+    EMPLOYMENT_WA_1_0("employment_wa_1_0"),
+    PRIVATELAW_WA_1_2("privatelaw_wa_1_2"),;
     
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/util/UtilityFunctions.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/util/UtilityFunctions.java
@@ -1,7 +1,15 @@
-package validationrules.core;
+package uk.gov.hmcts.reform.orgrolemapping.util;
 
-function String getJurisdictionFromServiceCode(String serviceCode) {
-    String result = null;
+import javax.inject.Singleton;
+
+@Singleton
+public final class UtilityFunctions {
+
+    private UtilityFunctions() {
+    }
+
+    public static String getJurisdictionFromServiceCode(final String serviceCode) {
+        String result = null;
         switch (serviceCode) {
             case "BBA3":
                 result = "SSCS";
@@ -21,4 +29,5 @@ function String getJurisdictionFromServiceCode(String serviceCode) {
                 break;
         }
         return result;
+    }
 }

--- a/src/main/resources/db/migration/V20230711_2861__AM-2861_PRL_Add_New_Caseworker_roles.sql
+++ b/src/main/resources/db/migration/V20230711_2861__AM-2861_PRL_Add_New_Caseworker_roles.sql
@@ -1,0 +1,7 @@
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('privatelaw_wa_1_2', 'local', 'iac', 'true');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('privatelaw_wa_1_2', 'pr', 'iac', 'true');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('privatelaw_wa_1_2', 'aat', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('privatelaw_wa_1_2', 'demo', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('privatelaw_wa_1_2', 'perftest', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('privatelaw_wa_1_2', 'ithc', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('privatelaw_wa_1_2', 'prod', 'iac', 'false');

--- a/src/main/resources/validationrules/core/hearing-role-admin-global.drl
+++ b/src/main/resources/validationrules/core/hearing-role-admin-global.drl
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.FeatureFlag;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.FeatureFlagEnum;
 import function uk.gov.hmcts.reform.orgrolemapping.domain.service.RequestMappingService.logMsg;
+import function uk.gov.hmcts.reform.orgrolemapping.util.UtilityFunctions.getJurisdictionFromServiceCode;
 
 /*
  * For on-boarding new service, we just need to include the corresponding service code in every

--- a/src/main/resources/validationrules/core/hearing-role-caseworker-global.drl
+++ b/src/main/resources/validationrules/core/hearing-role-caseworker-global.drl
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.FeatureFlag;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.FeatureFlagEnum;
 import function uk.gov.hmcts.reform.orgrolemapping.domain.service.RequestMappingService.logMsg;
+import function uk.gov.hmcts.reform.orgrolemapping.util.UtilityFunctions.getJurisdictionFromServiceCode;
 
 /*
  * For on-boarding new service, we just need to include the corresponding service code in every

--- a/src/main/resources/validationrules/core/hearing-role-ctsc-global.drl
+++ b/src/main/resources/validationrules/core/hearing-role-ctsc-global.drl
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.FeatureFlag;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.FeatureFlagEnum;
 import function uk.gov.hmcts.reform.orgrolemapping.domain.service.RequestMappingService.logMsg;
+import function uk.gov.hmcts.reform.orgrolemapping.util.UtilityFunctions.getJurisdictionFromServiceCode;
 
 /*
  * For on-boarding new service, we just need to include the corresponding service code in every

--- a/src/main/resources/validationrules/privatelaw/privatelaw-other-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-other-mapping.drl
@@ -1,0 +1,70 @@
+package validationrules.privatelaw;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.RoleAssignment;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.ActorIdType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.RoleCategory;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.RoleType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.Classification;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.GrantType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.CaseWorkerAccessProfile;
+import  uk.gov.hmcts.reform.orgrolemapping.util.JacksonUtils;
+import java.util.HashMap
+import java.util.Map
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.FeatureFlag;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.FeatureFlagEnum;
+import function uk.gov.hmcts.reform.orgrolemapping.domain.service.RequestMappingService.logMsg;
+import function uk.gov.hmcts.reform.orgrolemapping.util.UtilityFunctions.getJurisdictionFromServiceCode;
+
+/*
+ * Private Law "listed-hearing-viewer" Org role mapping.
+ */
+rule "private_law_cymru_caseworker_hearing_viewer_other_gov_dept"
+when
+  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_2.getValue())
+  $up: CaseWorkerAccessProfile(roleId in ("TBC"), serviceCode in ("ABA5"), !suspended)
+then
+   Map<String,JsonNode> attribute = new HashMap<>();
+   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode(getJurisdictionFromServiceCode($up.getServiceCode())));
+   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($up.getPrimaryLocationId()));
+
+  insert(
+      RoleAssignment.builder()
+      .actorIdType(ActorIdType.IDAM)
+      .actorId($up.getId())
+      .roleCategory(RoleCategory.OTHER_GOV_DEPT)
+      .roleType(RoleType.ORGANISATION)
+      .roleName("listed-hearing-viewer")
+      .grantType(GrantType.STANDARD)
+      .classification(Classification.PUBLIC)
+      .readOnly(false)
+      .attributes(attribute)
+      .build());
+      logMsg("Rule : private_law_cymru_caseworker_hearing_viewer_other_gov_dept");
+end;
+
+/*
+ * Private Law "caseworker-privatelaw-cafcass-cymru" Org role mapping.
+ */
+rule "private_law_cymru_caseworker_cafcass_other_gov_dept"
+when
+  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_2.getValue())
+  $up: CaseWorkerAccessProfile(roleId in ("TBC"), serviceCode in ("ABA5"), !suspended)
+then
+   Map<String,JsonNode> attribute = new HashMap<>();
+   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode(getJurisdictionFromServiceCode($up.getServiceCode())));
+   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($up.getPrimaryLocationId()));
+
+  insert(
+      RoleAssignment.builder()
+      .actorIdType(ActorIdType.IDAM)
+      .actorId($up.getId())
+      .roleCategory(RoleCategory.OTHER_GOV_DEPT)
+      .roleType(RoleType.ORGANISATION)
+      .roleName("caseworker-privatelaw-cafcass-cymru")
+      .grantType(GrantType.STANDARD)
+      .classification(Classification.PUBLIC)
+      .readOnly(false)
+      .attributes(attribute)
+      .build());
+      logMsg("Rule : private_law_cymru_caseworker_cafcass_other_gov_dept");
+end;

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolPrivateLawOtherGovDeptStaffRoleMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolPrivateLawOtherGovDeptStaffRoleMappingTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.orgrolemapping.domain.service;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.RoleAssignment;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.RoleCategory;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static uk.gov.hmcts.reform.orgrolemapping.helper.TestDataBuilder.buildUserAccessProfile3;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DroolPrivateLawOtherGovDeptStaffRoleMappingTest extends DroolBase {
+
+    static final String LD_FLAG = "privatelaw_wa_1_2";
+
+    @ParameterizedTest
+    @CsvSource({
+            "TBC,ABA5,PRIVATELAW"
+    })
+    void shouldReturnListedHearingViewerCaseWorker_otherGovDept(String roleId, String serviceCode,
+                                                                String jurisdiction) {
+        allProfiles.add(buildUserAccessProfile3(serviceCode, roleId, ""));
+
+        //Execute Kie session
+        List<RoleAssignment> roleAssignments = buildExecuteKieSession(getFeatureFlags(LD_FLAG, true));
+
+        //assertion
+        assertFalse(roleAssignments.isEmpty());
+        assertEquals(2, roleAssignments.size());
+        roleAssignments.forEach(r -> {
+            assertEquals(RoleCategory.OTHER_GOV_DEPT, r.getRoleCategory());
+            assertEquals(usersAccessProfiles.keySet().stream().iterator().next(), r.getActorId());
+            assertEquals(jurisdiction, r.getAttributes().get("jurisdiction").asText());
+            assertThat(r.getRoleName())
+                    .matches(s -> Stream.of("listed-hearing-viewer", "caseworker-privatelaw-cafcass-cymru")
+                            .anyMatch(s::contains));
+        });
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/AM-2861

### Change description ###
Configure new drool rules for Private Law - Cafcass Cymrus
- add new private law 1.2 flag
- move utlity function into Java class to allow it to be imported by all drool rules outside of core package
- add tests
- use TBC instead of role ID whilst waiting for RD to provide us with the correct role ID