### PR TITLE
AM-2851 CVE-2023-2976 guava 32.0.1-jre, launchDarklySdk 5.10.9, suppr…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ def versions = [
         drools         : '7.73.0.Final',
         log4JVersion   : '2.20.0',
         logbackVersion : '1.2.10',
-        launchDarklySdk: '5.10.8',
+        launchDarklySdk: '5.10.9',
         netty_version  : '4.1.94.Final'
 
 ]
@@ -382,7 +382,7 @@ dependencies {
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.5.3'
     implementation group: 'commons-cli', name: 'commons-cli', version: '1.4'
     implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: versions.launchDarklySdk
-    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
     implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.6'
     implementation group: 'org.apache.maven', name: 'maven-core', version: '3.8.7'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -9,8 +9,4 @@
         <notes>https://tools.hmcts.net/jira/browse/AM-2839 jackson-databind</notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
-    <suppress>
-        <notes>https://tools.hmcts.net/jira/browse/AM-2851 guava</notes>
-        <cve>CVE-2023-2976</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2851
CVE-2023-2976 guava 32.0.1-jre, launchDarklySdk 5.10.9, suppression removed


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
