### PR TITLE
AM-2894 patch to PR 1540

### DIFF
--- a/charts/am-org-role-mapping-service/values.aat.template.yaml
+++ b/charts/am-org-role-mapping-service/values.aat.template.yaml
@@ -6,3 +6,4 @@ java:
     ENABLE_CACHE: none
     ORG_ROLE_MAPPING_DB_HOST: am-org-role-mapping-service-postgres-db-v11-{{ .Values.global.environment }}.postgres.database.azure.com
     ORG_ROLE_MAPPING_DB_USERNAME: am@am-org-role-mapping-service-postgres-db-v11-{{ .Values.global.environment }}
+    TESTING_SUPPORT_ENABLED: true

--- a/charts/am-org-role-mapping-service/values.preview.template.yaml
+++ b/charts/am-org-role-mapping-service/values.preview.template.yaml
@@ -49,6 +49,7 @@ java:
     ORG_ROLE_MAPPING_DB_PASSWORD: "{{ .Values.postgresql.auth.password}}"
     ORG_ROLE_MAPPING_DB_PORT: "{{ .Values.postgresql.auth.port}}"
     ORG_ROLE_MAPPING_DB_OPTIONS: "?stringtype=unspecified"
+    TESTING_SUPPORT_ENABLED: true
     RUN_LD_ON_STARTUP: true
   postgresql:
     enabled: true

--- a/charts/am-org-role-mapping-service/values.yaml
+++ b/charts/am-org-role-mapping-service/values.yaml
@@ -44,6 +44,7 @@ java:
     ORG_ROLE_MAPPING_DB_USERNAME: am@am-org-role-mapping-service-postgres-db-v11-{{ .Values.global.environment }}
     ORG_ROLE_MAPPING_DB_OPTIONS: "?stringtype=unspecified&sslmode=require"
     REFRESH_JOB:
+    TESTING_SUPPORT_ENABLED: false
     APPLICATION_LOGGING_LEVEL: INFO
     RUN_LD_ON_STARTUP: true
 servicebus:

--- a/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/config/SwaggerPublisher.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/config/SwaggerPublisher.java
@@ -2,10 +2,12 @@ package uk.gov.hmcts.reform.orgrolemapping.config;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.reform.orgrolemapping.controller.BaseTest;
+
 import javax.inject.Inject;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -20,6 +22,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Each run of workflow .github/workflows/swagger.yml on master should automatically save and upload (if updated)
  * documentation.
  */
+@TestPropertySource(properties = {
+    // NB: hide testing-support endpoint from Swagger Publish
+    "testing.support.enabled=false"
+})
 public class SwaggerPublisher extends BaseTest {
 
     private MockMvc mockMvc;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/controller/WelcomeControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/controller/WelcomeControllerIntegrationTest.java
@@ -69,7 +69,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.reform.orgrolemapping.helper.UserAccessProfileBuilder.buildJudicialProfile;
 
 
-@TestPropertySource(properties = {"dbFeature.flags.enable=iac_jrd_1_0"})
+@TestPropertySource(properties = {
+    "dbFeature.flags.enable=iac_jrd_1_0",
+    "testing.support.enabled=true" // NB: needed for OrgMappingController (needs removing in AM-2877)
+})
 public class WelcomeControllerIntegrationTest extends BaseTest {
 
     private static final Logger logger = LoggerFactory.getLogger(WelcomeControllerIntegrationTest.class);

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/config/SwaggerConfiguration.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.GroupedOpenApi;
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.HandlerMethod;
@@ -29,7 +30,17 @@ public class SwaggerConfiguration {
     public GroupedOpenApi publicApi(OperationCustomizer customGlobalHeaders) {
         return GroupedOpenApi.builder()
                 .group("am-org-role-mapping-service")
-                .pathsToMatch("/**")
+                .pathsToMatch("/am/role-mapping/**")
+                .build();
+    }
+
+    @ConditionalOnProperty(name = "testing.support.enabled", havingValue = "true")
+    @Bean
+    GroupedOpenApi testingSupportApis(OperationCustomizer customGlobalHeaders) {
+        return GroupedOpenApi.builder()
+                .group("testing-support")
+                .displayName("Testing Support")
+                .pathsToMatch("/am/testing-support/**")
                 .build();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/controller/WelcomeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/controller/WelcomeController.java
@@ -1,46 +1,20 @@
 package uk.gov.hmcts.reform.orgrolemapping.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.Hidden;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
-import uk.gov.hmcts.reform.orgrolemapping.domain.model.UserRequest;
-import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.UserType;
-import uk.gov.hmcts.reform.orgrolemapping.domain.service.BulkAssignmentOrchestrator;
-import uk.gov.hmcts.reform.orgrolemapping.v1.V1;
 
 import static org.springdoc.core.Constants.SWAGGER_UI_URL;
-import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.AUTHORIZATION;
-import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.SERVICE_AUTHORIZATION;
 
 @RestController
 @Slf4j
-@NoArgsConstructor
 @Hidden
 public class WelcomeController {
 
-    private BulkAssignmentOrchestrator bulkAssignmentOrchestrator;
-
-
-    @Autowired
-    public WelcomeController(
-            BulkAssignmentOrchestrator bulkAssignmentOrchestrator) {
-        this.bulkAssignmentOrchestrator = bulkAssignmentOrchestrator;
-    }
 
     @GetMapping(value = "/swagger")
     public RedirectView swaggerRedirect() {
@@ -51,43 +25,6 @@ public class WelcomeController {
     public String welcome() {
         return "Welcome to Organisation Role Mapping Service";
     }
-    //This is just a test API
-
-    @PostMapping(
-            path = "/am/role-mapping/staff/users",
-            produces = V1.MediaType.MAP_ASSIGNMENTS,
-            consumes = {"application/json"}
-    )
-    @ResponseStatus(code = HttpStatus.OK)
-    @Operation(summary = "creates multiple role assignments based upon user profile mapping rules",
-            security =
-            {
-                @SecurityRequirement(name = AUTHORIZATION),
-                @SecurityRequirement(name = SERVICE_AUTHORIZATION)
-            })
-    @ApiResponse(
-            responseCode = "200",
-            description = "OK",
-            content = @Content(schema = @Schema(implementation = Object.class))
-    )
-    @ApiResponse(
-            responseCode = "400",
-            description = V1.Error.INVALID_REQUEST,
-            content = @Content()
-    )
-    public ResponseEntity<Object> createOrgMapping(@RequestBody UserRequest userRequest,
-                                                   @RequestHeader(value = "userType")
-                                                           UserType userType) {
-        var startTime = System.currentTimeMillis();
-        log.debug("createOrgMapping");
-        log.info("Process has been Started for the userIds {}", userRequest.getUserIds());
-        ResponseEntity<Object> response = bulkAssignmentOrchestrator.createBulkAssignmentsRequest(userRequest,
-                userType);
-        log.debug("Execution time of createOrgMapping() : {} ms",
-                (Math.subtractExact(System.currentTimeMillis(), startTime)));
-        return ResponseEntity.status(response.getStatusCode()).body(response.getBody());
-    }
-
 
     //This method needed for the functional tests, so that RAS gets enough time to create records.
     @PostMapping(value = "/sleep")
@@ -95,4 +32,5 @@ public class WelcomeController {
         return ResponseEntity.ok("Sleep time for Functional tests is over");
 
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/controller/testingsupport/OrgMappingController.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/controller/testingsupport/OrgMappingController.java
@@ -1,0 +1,100 @@
+package uk.gov.hmcts.reform.orgrolemapping.controller.testingsupport;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.UserRequest;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.UserType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.service.BulkAssignmentOrchestrator;
+import uk.gov.hmcts.reform.orgrolemapping.v1.V1;
+
+import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.AUTHORIZATION;
+import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.SERVICE_AUTHORIZATION;
+
+@RestController
+@Slf4j
+@NoArgsConstructor
+@ConditionalOnProperty(name = "testing.support.enabled", havingValue = "true")
+public class OrgMappingController {
+
+    private BulkAssignmentOrchestrator bulkAssignmentOrchestrator;
+
+
+    @Autowired
+    public OrgMappingController(
+            BulkAssignmentOrchestrator bulkAssignmentOrchestrator) {
+        this.bulkAssignmentOrchestrator = bulkAssignmentOrchestrator;
+    }
+
+    @PostMapping(
+            path = "/am/testing-support/createOrgMapping",
+            produces = V1.MediaType.MAP_ASSIGNMENTS,
+            consumes = {"application/json"}
+    )
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "creates multiple role assignments based upon user profile mapping rules",
+            security =
+            {
+                @SecurityRequirement(name = AUTHORIZATION),
+                @SecurityRequirement(name = SERVICE_AUTHORIZATION)
+            })
+    @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = Object.class))
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = V1.Error.INVALID_REQUEST,
+            content = @Content()
+    )
+    public ResponseEntity<Object> createOrgMapping(@RequestBody UserRequest userRequest,
+                                                   @RequestParam(value = "userType")
+                                                           UserType userType) {
+        var startTime = System.currentTimeMillis();
+        log.debug("createOrgMapping");
+        log.info("Process has been Started for the userIds {}", userRequest.getUserIds());
+        ResponseEntity<Object> response = bulkAssignmentOrchestrator.createBulkAssignmentsRequest(userRequest,
+                userType);
+        log.debug("Execution time of createOrgMapping() : {} ms",
+                (Math.subtractExact(System.currentTimeMillis(), startTime)));
+        return ResponseEntity.status(response.getStatusCode()).body(response.getBody());
+    }
+
+
+    /**
+     * Create Org Mappings endpoint using old URL and header parameter.
+     *
+     * @deprecated Use {@link OrgMappingController#createOrgMapping(UserRequest, UserType)}
+     */
+    @SuppressWarnings({"squid:S1133", "DeprecatedIsStillUsed"})
+    @Deprecated(forRemoval = true)
+    @PostMapping(
+            path = "/am/role-mapping/staff/users",
+            produces = V1.MediaType.MAP_ASSIGNMENTS,
+            consumes = {"application/json"}
+    )
+    @ResponseStatus(code = HttpStatus.OK)
+    @Hidden
+    public ResponseEntity<Object> createOrgMappingDeprecated(@RequestBody UserRequest userRequest,
+                                                             @RequestHeader(value = "userType")
+                                                             UserType userType) {
+        return createOrgMapping(userRequest, userType);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDMessagingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDMessagingConfiguration.java
@@ -6,6 +6,7 @@ import com.azure.messaging.servicebus.ServiceBusSenderClient;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -31,6 +32,7 @@ public class CRDMessagingConfiguration {
     String environment;
 
     @Bean("crdPublisher")
+    @ConditionalOnProperty(name = "amqp.crd.enabled", havingValue = "true")
     public ServiceBusSenderClient getServiceBusSenderClient() {
         log.debug("Getting the ServiceBusSenderClient in CRD");
         logServiceBusVariables();

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDMessagingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDMessagingConfiguration.java
@@ -6,7 +6,7 @@ import com.azure.messaging.servicebus.ServiceBusSenderClient;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -32,7 +32,7 @@ public class CRDMessagingConfiguration {
     String environment;
 
     @Bean("crdPublisher")
-    @ConditionalOnProperty(name = "amqp.crd.enabled", havingValue = "true")
+    @ConditionalOnExpression("${testing.support.enabled} && ${amqp.crd.enabled}")
     public ServiceBusSenderClient getServiceBusSenderClient() {
         log.debug("Getting the ServiceBusSenderClient in CRD");
         logServiceBusVariables();

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDTopicPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDTopicPublisher.java
@@ -8,6 +8,7 @@ import com.launchdarkly.shaded.org.jetbrains.annotations.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "amqp.crd.enabled", havingValue = "true")
 public class CRDTopicPublisher extends CRDMessagingConfiguration {
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDTopicPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/CRDTopicPublisher.java
@@ -8,7 +8,7 @@ import com.launchdarkly.shaded.org.jetbrains.annotations.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
-@ConditionalOnProperty(name = "amqp.crd.enabled", havingValue = "true")
+@ConditionalOnExpression("${testing.support.enabled} && ${amqp.crd.enabled}")
 public class CRDTopicPublisher extends CRDMessagingConfiguration {
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDMessagingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDMessagingConfiguration.java
@@ -6,6 +6,7 @@ import com.azure.messaging.servicebus.ServiceBusSenderClient;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -31,6 +32,7 @@ public class JRDMessagingConfiguration {
     String environment;
 
     @Bean("jrdPublisher")
+    @ConditionalOnProperty(name = "amqp.jrd.enabled", havingValue = "true")
     public ServiceBusSenderClient getServiceBusSenderClient() {
         log.debug("Getting the ServiceBusSenderClient in JRD");
         logServiceBusVariables();

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDMessagingConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDMessagingConfiguration.java
@@ -6,7 +6,7 @@ import com.azure.messaging.servicebus.ServiceBusSenderClient;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -32,7 +32,7 @@ public class JRDMessagingConfiguration {
     String environment;
 
     @Bean("jrdPublisher")
-    @ConditionalOnProperty(name = "amqp.jrd.enabled", havingValue = "true")
+    @ConditionalOnExpression("${testing.support.enabled} && ${amqp.jrd.enabled}")
     public ServiceBusSenderClient getServiceBusSenderClient() {
         log.debug("Getting the ServiceBusSenderClient in JRD");
         logServiceBusVariables();

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDTopicPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDTopicPublisher.java
@@ -8,6 +8,7 @@ import com.launchdarkly.shaded.org.jetbrains.annotations.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(name = "amqp.jrd.enabled", havingValue = "true")
 public class JRDTopicPublisher extends JRDMessagingConfiguration {
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDTopicPublisher.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/JRDTopicPublisher.java
@@ -8,7 +8,7 @@ import com.launchdarkly.shaded.org.jetbrains.annotations.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -21,7 +21,7 @@ import java.util.Objects;
 
 @Slf4j
 @Service
-@ConditionalOnProperty(name = "amqp.jrd.enabled", havingValue = "true")
+@ConditionalOnExpression("${testing.support.enabled} && ${amqp.jrd.enabled}")
 public class JRDTopicPublisher extends JRDMessagingConfiguration {
 
     @Autowired

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/TopicController.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/TopicController.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 @Slf4j
 @NoArgsConstructor
 @Hidden
-@ConditionalOnExpression("${amqp.crd.enabled} || ${amqp.jrd.enabled}")
+@ConditionalOnExpression("${testing.support.enabled} && (${amqp.crd.enabled} || ${amqp.jrd.enabled})")
 public class TopicController {
 
     JRDTopicPublisher jrdTopicPublisher;

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/TopicController.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/servicebus/TopicController.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.orgrolemapping.servicebus;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 @Slf4j
 @NoArgsConstructor
 @Hidden
+@ConditionalOnExpression("${amqp.crd.enabled} || ${amqp.jrd.enabled}")
 public class TopicController {
 
     JRDTopicPublisher jrdTopicPublisher;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -164,6 +164,10 @@ refresh:
     sortColumn: ${REFRESH_JOB_SORT_COL:}
     authorisedServices: am_org_role_mapping_service,am_role_assignment_refresh_batch
 
+testing:
+  support:
+    enabled: ${TESTING_SUPPORT_ENABLED:false}
+
 dbFeature:
   flags:
     enable: ${DB_FEATURE_FLAG_ENABLE:}

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/controller/WelcomeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/controller/WelcomeControllerTest.java
@@ -1,38 +1,19 @@
 package uk.gov.hmcts.reform.orgrolemapping.controller;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.orgrolemapping.controller.advice.ErrorConstants;
-import uk.gov.hmcts.reform.orgrolemapping.domain.model.UserRequest;
-import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.UserType;
-import uk.gov.hmcts.reform.orgrolemapping.domain.service.BulkAssignmentOrchestrator;
-import uk.gov.hmcts.reform.orgrolemapping.helper.TestDataBuilder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.springdoc.core.Constants.SWAGGER_UI_URL;
 
 class WelcomeControllerTest {
 
-    @Mock
-    private BulkAssignmentOrchestrator bulkAssignmentOrchestrator;
 
-
-    @InjectMocks
-    private final WelcomeController sut = new WelcomeController(bulkAssignmentOrchestrator);
-
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
+    private final WelcomeController sut = new WelcomeController();
 
     @Test
     void swaggerRedirect() {
@@ -49,47 +30,6 @@ class WelcomeControllerTest {
     }
 
     @Test
-    void createOrgMappingTest() {
-        UserRequest userRequest = TestDataBuilder.buildUserRequest();
-
-        ResponseEntity<Object> response =
-                ResponseEntity.status(HttpStatus.CREATED).body(userRequest);
-
-        Mockito.when(bulkAssignmentOrchestrator.createBulkAssignmentsRequest(Mockito.any(UserRequest.class),
-                eq(UserType.CASEWORKER)))
-                .thenReturn(response);
-
-        assertEquals(response, sut.createOrgMapping(userRequest, UserType.CASEWORKER));
-    }
-
-    @Test
-    void createOrgMappingTest_Judicial() {
-        UserRequest userRequest = TestDataBuilder.buildUserRequest();
-
-        ResponseEntity<Object> response =
-                ResponseEntity.status(HttpStatus.CREATED).body(userRequest);
-
-        Mockito.when(bulkAssignmentOrchestrator.createBulkAssignmentsRequest(Mockito.any(UserRequest.class),
-                        eq(UserType.JUDICIAL)))
-                .thenReturn(response);
-
-        assertEquals(response, sut.createOrgMapping(userRequest, UserType.JUDICIAL));
-    }
-
-    @Test
-    void createOrgMappingTest_Unprocessable() {
-        UserRequest userRequest = TestDataBuilder.buildUserRequest();
-        ResponseEntity<Object> response =
-                ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(null);
-
-        Mockito.when(bulkAssignmentOrchestrator.createBulkAssignmentsRequest(Mockito.any(UserRequest.class),
-                        eq(UserType.JUDICIAL)))
-                .thenReturn(response);
-
-        assertEquals(response, sut.createOrgMapping(userRequest, UserType.JUDICIAL));
-    }
-
-    @Test
     void functionalSleepTest() {
         ResponseEntity<Object> response =
                 ResponseEntity.status(HttpStatus.OK).body("Sleep time for Functional tests is over");
@@ -102,6 +42,5 @@ class WelcomeControllerTest {
         assertEquals(202, ErrorConstants.ACCEPTED.getErrorCode());
         assertEquals("Accepted", ErrorConstants.ACCEPTED.getErrorMessage());
     }
-
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/controller/testingsupport/OrgMappingControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/controller/testingsupport/OrgMappingControllerTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.reform.orgrolemapping.controller.testingsupport;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.UserRequest;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.UserType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.service.BulkAssignmentOrchestrator;
+import uk.gov.hmcts.reform.orgrolemapping.helper.TestDataBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+
+class OrgMappingControllerTest {
+
+    @Mock
+    private BulkAssignmentOrchestrator bulkAssignmentOrchestrator;
+
+
+    @InjectMocks
+    private final OrgMappingController sut = new OrgMappingController(bulkAssignmentOrchestrator);
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createOrgMappingTest() {
+        UserRequest userRequest = TestDataBuilder.buildUserRequest();
+
+        ResponseEntity<Object> response =
+                ResponseEntity.status(HttpStatus.CREATED).body(userRequest);
+
+        Mockito.when(bulkAssignmentOrchestrator.createBulkAssignmentsRequest(Mockito.any(UserRequest.class),
+                eq(UserType.CASEWORKER)))
+                .thenReturn(response);
+
+        assertEquals(response, sut.createOrgMapping(userRequest, UserType.CASEWORKER));
+    }
+
+    @Test
+    void createOrgMappingTest_Judicial() {
+        UserRequest userRequest = TestDataBuilder.buildUserRequest();
+
+        ResponseEntity<Object> response =
+                ResponseEntity.status(HttpStatus.CREATED).body(userRequest);
+
+        Mockito.when(bulkAssignmentOrchestrator.createBulkAssignmentsRequest(Mockito.any(UserRequest.class),
+                        eq(UserType.JUDICIAL)))
+                .thenReturn(response);
+
+        assertEquals(response, sut.createOrgMapping(userRequest, UserType.JUDICIAL));
+    }
+
+    @Test
+    void createOrgMappingTest_Unprocessable() {
+        UserRequest userRequest = TestDataBuilder.buildUserRequest();
+        ResponseEntity<Object> response =
+                ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(null);
+
+        Mockito.when(bulkAssignmentOrchestrator.createBulkAssignmentsRequest(Mockito.any(UserRequest.class),
+                        eq(UserType.JUDICIAL)))
+                .thenReturn(response);
+
+        assertEquals(response, sut.createOrgMapping(userRequest, UserType.JUDICIAL));
+    }
+
+    @SuppressWarnings("removal") // suppress warning on use of deprecated endpoint
+    @Test
+    void createOrgMappingTest_deprecatedEndpoint() {
+        UserRequest userRequest = TestDataBuilder.buildUserRequest();
+
+        ResponseEntity<Object> response =
+                ResponseEntity.status(HttpStatus.CREATED).body(userRequest);
+
+        Mockito.when(bulkAssignmentOrchestrator.createBulkAssignmentsRequest(Mockito.any(UserRequest.class),
+                eq(UserType.CASEWORKER)))
+                .thenReturn(response);
+
+        assertEquals(response, sut.createOrgMappingDeprecated(userRequest, UserType.CASEWORKER));
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [AM-2894](https://tools.hmcts.net/jira/browse/AM-2894) _"Allow option to start up ORM but without ServiceBus integration"_

### Change description ###

Disable Azure Service Bus Topic Publishers when ASB disabled.

Refactor the test ORM refresh endpoint:
* rename,
* enable swagger,
* hide/disable behind `TESTING_SUPPORT_ENABLED` env variable.

> NB: This PR is a patch to #1540. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
