### PR TITLE
AM-3068 Pitest failures in Nightly - pitest-junit5-plugin upgraded to…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath("net.serenity-bdd:serenity-gradle-plugin:2.4.34")
-        classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.7.4'
+        classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.15.0'
     }
 }
 
@@ -16,7 +16,7 @@ plugins {
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'org.springframework.boot' version '2.7.17'
-    id 'info.solidsoft.pitest' version '1.7.4'
+    id 'info.solidsoft.pitest' version '1.15.0'
     id 'com.github.ben-manes.versions' version '0.45.0'
     id 'org.sonarqube' version '4.0.0.2929'
     id 'au.com.dius.pact' version '4.3.12'
@@ -36,7 +36,7 @@ ext['snakeyaml.version'] = '2.0'
 def versions = [
         junit          : '5.9.0',
         lombok         : '1.18.30',
-        pitest         : '1.7.4',
+        pitest         : '1.15.3',
         reformLogging  : '6.0.1',
         reformS2sClient: '4.0.2',
         serenity       : '2.2.12',
@@ -465,7 +465,7 @@ dependencies {
     testImplementation('com.github.tomakehurst:wiremock-jre8-standalone:2.35.1')
     testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
 
-    pitest 'org.pitest:pitest-junit5-plugin:0.16'
+    pitest 'org.pitest:pitest-junit5-plugin:1.2.1'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
@@ -475,7 +475,7 @@ dependencies {
     testImplementation group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.9.2'
 
     testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
-    testImplementation group: 'info.solidsoft.gradle.pitest', name:'gradle-pitest-plugin', version: versions.pitest
+    testImplementation group: 'info.solidsoft.gradle.pitest', name:'gradle-pitest-plugin', version: '1.15.0'
     testImplementation 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
     testImplementation('org.springframework.cloud:spring-cloud-contract-wiremock:3.1.8')
     testImplementation group: 'org.springframework.boot', name:'spring-boot-starter-test', version: versions.springBoot


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3068
AM-3068 Pitest failures in Nightly - pitest-junit5-plugin upgraded to 1.2.1 allowing other pitest components to be upgraded to 1.15.x

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
