### PR TITLE
DTSAM-147 Retire old rules after PRIVATELAW_WA_1_3 Go Live

### DIFF
--- a/src/main/resources/validationrules/privatelaw/privatelaw-judicial-org-role-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-judicial-org-role-mapping.drl
@@ -17,42 +17,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.FeatureFlagEnum;
 import function uk.gov.hmcts.reform.orgrolemapping.domain.service.RequestMappingService.logMsg;
 
-
-/*
- * PRIVATELAW "judge" Org role mapping.
- */
-rule "privatelaw_judge_org_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false, flagName == FeatureFlagEnum.PRIVATELAW_WA_1_3.getValue())
-  $joh: JudicialOfficeHolder(office in ( "PRIVATELAW District Judge-Salaried", "PRIVATELAW Presiding Judge-Salaried",
-                                         "PRIVATELAW Resident Judge-Salaried", "PRIVATELAW Designated Family Judge-Salaried",
-                                         "PRIVATELAW District Judge (MC)-Salaried"))
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Salaried"));
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications"));
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($joh.getBeginTime())
-      .endTime($joh.getEndTime() !=null ? $joh.getEndTime().plusDays(1):null)
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_judge_org_role");
-end;
-
 /*
  * PRIVATELAW "judge" Org role mapping.
  */
@@ -366,52 +330,6 @@ then
       .build());
       logMsg("Rule : privatelaw_circuit_judge_org_role_for_fee_paid_judge");
 end;
-
-/*
- * PRIVATELAW "judge" org role can be created by any existing judicial office holder having
- * "PRIVATELAW Deputy Judge-Fee-Paid, PRIVATELAW Recorder-Fee-Paid,PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid" business role.
- */
-rule "privatelaw_judge_org_role_for_fee_paid_judge"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false, flagName == FeatureFlagEnum.PRIVATELAW_WA_1_3.getValue())
-  $joh: JudicialOfficeHolder(office in ("PRIVATELAW Deputy District Judge-Fee-Paid",
-                                        "PRIVATELAW Recorder-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – PRFD-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Deputy High Court Judge-Fee-Paid",
-                                        "PRIVATELAW High Court Judge - Sitting in Retirement-Fee-Paid"))
-  $bk: JudicialBooking(userId == $joh.userId)
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($bk.getLocationId() != null ?
-   $bk.getLocationId():$joh.getPrimaryLocation()));
-   attribute.put("baseLocation", JacksonUtils.convertObjectIntoJsonNode($bk.getLocationId()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($bk.getRegionId()));
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Fee-Paid"));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications"));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($bk.getBeginTime())
-      .endTime($bk.getEndTime())
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_judge_org_role_for_fee_paid_judge");
-end;
-
 
 /*
  * PRIVATELAW "judge" org role can be created by any existing judicial office holder having

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolPrivateLawJudicialRoleMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolPrivateLawJudicialRoleMappingTest.java
@@ -11,11 +11,16 @@ import uk.gov.hmcts.reform.orgrolemapping.domain.model.FeatureFlag;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.JudicialAccessProfile;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.JudicialBooking;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.RoleAssignment;
-import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.Classification;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.ActorIdType;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.GrantType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.RoleCategory;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.RoleType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.Classification;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -23,14 +28,85 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 class DroolPrivateLawJudicialRoleMappingTest extends DroolBase {
 
-    String userId = "3168da13-00b3-41e3-81fa-cbc71ac28a69";
+    static final String REGION_ID = "LDN";
+    static final String JURISDICTION = "PRIVATELAW";
+    static final RoleCategory ROLE_CATEGORY = RoleCategory.JUDICIAL;
+
+    static final String USER_ID = "3168da13-00b3-41e3-81fa-cbc71ac28a69";
+    static final String PRIMARY_LOCATION_ID = "London";
+    static final String BOOKING_LOCATION_ID = "Scotland";
+    static final String BOOKING_REGION_ID = "1";
+    static final String SERVICE_CODES = "ABA5";
+    static Map<String, String> expectedRoleNameWorkTypesMap = new HashMap<>();
+
+    {
+        expectedRoleNameWorkTypesMap.put("judge", "hearing_work,decision_making_work,applications");
+        expectedRoleNameWorkTypesMap.put("hmcts-judiciary", null);
+        expectedRoleNameWorkTypesMap.put("leadership-judge", null);
+        expectedRoleNameWorkTypesMap.put("task-supervisor", "routine_work,hearing_work,applications");
+        expectedRoleNameWorkTypesMap.put("case-allocator", null);
+        expectedRoleNameWorkTypesMap.put("specific-access-approver-judiciary", "access_requests");
+        expectedRoleNameWorkTypesMap.put("circuit-judge", "hearing_work,decision_making_work,applications");
+        expectedRoleNameWorkTypesMap.put("fee-paid-judge", "hearing_work,decision_making_work,applications");
+        expectedRoleNameWorkTypesMap.put("magistrate", "hearing_work, applications");
+    }
+
+    static void assertCommonRoleAssignmentAttributes(RoleAssignment r, String appointment) {
+        assertEquals(ActorIdType.IDAM, r.getActorIdType());
+        assertEquals(USER_ID, r.getActorId());
+        assertEquals(RoleType.ORGANISATION, r.getRoleType());
+        assertEquals(ROLE_CATEGORY, r.getRoleCategory());
+
+        String primaryLocation = null;
+        if (r.getAttributes().get("primaryLocation") != null) {
+            primaryLocation = r.getAttributes().get("primaryLocation").asText();
+        }
+
+        if (List.of("hmcts-judiciary").contains(
+                r.getRoleName())) {
+            assertEquals(Classification.PRIVATE, r.getClassification());
+            assertEquals(GrantType.BASIC, r.getGrantType());
+            assertEquals(null, r.getAttributes().get("jurisdiction"));
+            assertTrue(r.isReadOnly());
+            assertNull(primaryLocation);
+            assertNull(r.getAttributes().get("region"));
+        } else {
+            assertEquals(Classification.PUBLIC, r.getClassification());
+            assertEquals(GrantType.STANDARD, r.getGrantType());
+            assertEquals(JURISDICTION, r.getAttributes().get("jurisdiction").asText());
+            assertFalse(r.isReadOnly());
+            assertEquals(SERVICE_CODES, r.getAuthorisations().get(0));
+
+            if (bookingLocationAppointments.contains(appointment)
+                    && List.of("circuit-judge", "judge").contains(r.getRoleName())) {
+                assertEquals(BOOKING_LOCATION_ID, primaryLocation);
+                assertEquals(BOOKING_REGION_ID, r.getAttributes().get("region").asText());
+                assertEquals(BOOKING_LOCATION_ID, r.getAttributes().get("baseLocation").asText());
+            } else {
+                assertEquals(PRIMARY_LOCATION_ID, primaryLocation);
+                assertEquals(REGION_ID, r.getAttributes().get("region").asText());
+                assertNull(r.getAttributes().get("baseLocation"));
+            }
+
+        }
+
+        String expectedWorkTypes = expectedRoleNameWorkTypesMap.get(r.getRoleName());
+        String actualWorkTypes = null;
+        if (r.getAttributes().get("workTypes") != null) {
+            actualWorkTypes = r.getAttributes().get("workTypes").asText();
+        }
+        assertEquals(expectedWorkTypes, actualWorkTypes);
+    }
+
+
     List<String> judgeRoleNamesWithWorkTypes = List.of("judge", "circuit-judge", "fee-paid-judge");
-    List<String> bookingLocationAppointments = List.of(
+    static List<String> bookingLocationAppointments = List.of(
             "Deputy District Judge- Fee-Paid",
             "Deputy District Judge- Sitting in Retirement", "Recorder",
             "Deputy District Judge - PRFD",
@@ -47,113 +123,75 @@ class DroolPrivateLawJudicialRoleMappingTest extends DroolBase {
                 Arguments.of("Circuit Judge",
                         "Salaried",
                         List.of(""),
-                        List.of("circuit-judge", "hmcts-judiciary"),
-                        false),
-                Arguments.of("Circuit Judge",
-                        "Salaried",
-                        List.of(""),
-                        List.of("judge", "circuit-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "circuit-judge", "hmcts-judiciary")),
                 Arguments.of("Circuit Judge",
                         "SPTW",
                         List.of(""),
-                        List.of("circuit-judge", "hmcts-judiciary"),
-                        false),
-                Arguments.of("Circuit Judge",
-                        "SPTW",
-                        List.of(""),
-                        List.of("judge", "circuit-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "circuit-judge", "hmcts-judiciary")),
                 Arguments.of("Deputy Circuit Judge",
                         "Fee Paid",
                         List.of(""),
-                        List.of("circuit-judge", "fee-paid-judge", "hmcts-judiciary"),
-                        false),
-                Arguments.of("Deputy Circuit Judge",
-                        "Fee Paid",
-                        List.of(""),
-                        List.of("judge","circuit-judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge","circuit-judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("Deputy District Judge - PRFD",
                         "Fee Paid",
                         List.of("Deputy District Judge"),
-                        List.of("judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("Deputy District Judge (MC)- Fee paid",
                         "Fee Paid",
                         List.of("Deputy District Judge"),
-                        List.of("judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("Deputy District Judge (MC)- Sitting in Retirement",
                         "Fee Paid",
                         List.of("Deputy District Judge"),
-                        List.of("judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("Deputy District Judge- Fee-Paid",
                         "Fee Paid",
                         List.of(""),
-                        List.of("judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("Deputy District Judge- Sitting in Retirement",
                         "Fee Paid",
                         List.of(""),
-                        List.of("judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("Deputy High Court Judge",
                         "Fee Paid",
                         List.of("Deputy High Court Judge"),
-                        List.of("judge","fee-paid-judge","hmcts-judiciary"),
-                        true),
+                        List.of("judge","fee-paid-judge","hmcts-judiciary")),
                 Arguments.of("District Judge",
                         "Salaried",
                         List.of(""),
-                        List.of("judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "hmcts-judiciary")),
                 Arguments.of("District Judge (MC)",
                         "SPTW",
                         List.of("District Judge"),
-                        List.of("judge","hmcts-judiciary"),
-                        true),
+                        List.of("judge","hmcts-judiciary")),
                 Arguments.of("High Court Judge",
                         "Salaried",
                         List.of(""),
-                        List.of("circuit-judge", "hmcts-judiciary"),
-                        false),
-                Arguments.of("High Court Judge",
-                        "Salaried",
-                        List.of(""),
-                        List.of("judge", "circuit-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "circuit-judge", "hmcts-judiciary")),
                 Arguments.of("High Court Judge- Sitting in Retirement",
                         "Fee Paid",
                         List.of("High Court Judge"),
-                        List.of("judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("Recorder",
                         "Fee Paid",
                         List.of(""),
-                        List.of("judge", "fee-paid-judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "fee-paid-judge", "hmcts-judiciary")),
                 Arguments.of("",
                         "",
                         List.of("Designated Family Judge"),
                         List.of("leadership-judge","judge","task-supervisor","hmcts-judiciary","case-allocator",
-                                "specific-access-approver-judiciary"),
-                        true),
+                                "specific-access-approver-judiciary")),
                 Arguments.of("",
                         "",
                         List.of("Family Division Liaison Judge"),
-                        List.of("judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "hmcts-judiciary")),
                 Arguments.of("",
                         "",
                         List.of("Senior Family Liaison Judge"),
-                        List.of("judge", "hmcts-judiciary"),
-                        true),
+                        List.of("judge", "hmcts-judiciary")),
                 Arguments.of("Magistrate", "Voluntary",
                         List.of("Magistrates-Voluntary"),
-                        List.of("magistrate"),
-                        true
+                        List.of("magistrate")
                 )
         );
     }
@@ -161,26 +199,26 @@ class DroolPrivateLawJudicialRoleMappingTest extends DroolBase {
     @ParameterizedTest
     @MethodSource("endToEndData")
     void shouldTakeJudicialAccessProfileConvertToJudicialOfficeHolderThenReturnRoleAssignments(
-            String appointment, String appointmentType, List<String> assignedRoles, List<String> expectedRoleNames,
-            boolean privateLawV13IsEnabled) {
+            String appointment, String appointmentType, List<String> assignedRoles, List<String> expectedRoleNames) {
 
         judicialAccessProfiles.clear();
         judicialOfficeHolders.clear();
-        JudicialBooking booking = JudicialBooking.builder().userId(userId).locationId("Scotland").regionId("1").build();
+        JudicialBooking booking = JudicialBooking.builder().userId(USER_ID).locationId(BOOKING_LOCATION_ID)
+                .regionId(BOOKING_REGION_ID).build();
         judicialBookings.add(booking);
 
         judicialAccessProfiles.add(
                 JudicialAccessProfile.builder()
                         .appointment(appointment)
                         .appointmentType(appointmentType)
-                        .userId(userId)
+                        .userId(USER_ID)
                         .roles(assignedRoles)
-                        .regionId("LDN")
-                        .primaryLocationId("London")
-                        .ticketCodes(List.of("ABA5"))
+                        .regionId(REGION_ID)
+                        .primaryLocationId(PRIMARY_LOCATION_ID)
+                        .ticketCodes(List.of(SERVICE_CODES))
                         .authorisations(List.of(
                                 Authorisation.builder()
-                                        .serviceCodes(List.of("ABA5"))
+                                        .serviceCodes(List.of(SERVICE_CODES))
                                         .endDate(LocalDateTime.now().plusYears(1L))
                                         .build()
                         ))
@@ -188,9 +226,7 @@ class DroolPrivateLawJudicialRoleMappingTest extends DroolBase {
         );
 
         //Execute Kie session
-        List<RoleAssignment> roleAssignments = buildExecuteKieSession(List.of(
-                FeatureFlag.builder().flagName("privatelaw_wa_1_0").status(true).build(),
-                FeatureFlag.builder().flagName("privatelaw_wa_1_3").status(privateLawV13IsEnabled).build()));
+        List<RoleAssignment> roleAssignments = buildExecuteKieSession(getFeatureFlags());
 
         //assertions
         assertFalse(roleAssignments.isEmpty());
@@ -199,35 +235,9 @@ class DroolPrivateLawJudicialRoleMappingTest extends DroolBase {
                 roleAssignments.stream().map(RoleAssignment::getRoleName).collect(Collectors.toList());
         assertThat(roleNameResults, containsInAnyOrder(expectedRoleNames.toArray()));
 
-        roleAssignments.forEach(r -> {
-            assertEquals(userId, r.getActorId());
-            if (!r.getRoleName().contains("hmcts-judiciary")) {
-                assertEquals("ABA5", r.getAuthorisations().get(0));
-                if (judgeRoleNamesWithWorkTypes.contains(r.getRoleName())) {
-                    assertEquals("hearing_work,decision_making_work,applications",
-                            r.getAttributes().get("workTypes").asText());
-                } else if (r.getRoleName().contains("leadership-judge")) {
-                    assertEquals("LDN", r.getAttributes().get("region").asText());
-                }
-                if (bookingLocationAppointments.contains(appointment)
-                        && List.of("circuit-judge", "judge").contains(r.getRoleName())) {
-                    assertEquals(booking.getLocationId(), r.getAttributes().get("primaryLocation").asText());
-                    assertEquals(booking.getLocationId(), r.getAttributes().get("baseLocation").asText());
-                    assertEquals(booking.getRegionId(), r.getAttributes().get("region").asText());
-                } else {
-                    assertEquals("London", r.getAttributes().get("primaryLocation").asText());
-                    assertEquals("LDN", r.getAttributes().get("region").asText());
-                }
-            }
-            if ("magistrate".equals(r.getRoleName())) {
-                assertEquals(Classification.PUBLIC, r.getClassification());
-                assertEquals(GrantType.STANDARD, r.getGrantType());
-                assertEquals("ABA5", r.getAuthorisations().get(0));
-                assertEquals("LDN", r.getAttributes().get("region").asText());
-                assertEquals("London", r.getAttributes().get("primaryLocation").asText());
-                assertEquals("hearing_work, applications", r.getAttributes().get("workTypes").asText());
-            }
-        });
+        for (RoleAssignment r : roleAssignments) {
+            assertCommonRoleAssignmentAttributes(r,appointment);
+        }
     }
 
 
@@ -241,14 +251,14 @@ class DroolPrivateLawJudicialRoleMappingTest extends DroolBase {
                 JudicialAccessProfile.builder()
                         .appointment("District Judge (MC)")
                         .appointmentType("SPTW")
-                        .userId(userId)
+                        .userId(USER_ID)
                         .roles(List.of("District Judge"))
-                        .regionId("LDN")
-                        .primaryLocationId("London")
-                        .ticketCodes(List.of("ABA5"))
+                        .regionId(REGION_ID)
+                        .primaryLocationId(PRIMARY_LOCATION_ID)
+                        .ticketCodes(List.of(SERVICE_CODES))
                         .authorisations(List.of(
                                 Authorisation.builder()
-                                        .serviceCodes(List.of("ABA5"))
+                                        .serviceCodes(List.of(SERVICE_CODES))
                                         .endDate(LocalDateTime.now().plusYears(1L))
                                         .build()
                         ))
@@ -257,9 +267,20 @@ class DroolPrivateLawJudicialRoleMappingTest extends DroolBase {
 
         //Execute Kie session
         List<RoleAssignment> roleAssignments =
-                buildExecuteKieSession(getFeatureFlags("privatelaw_wa_1_0", false));
+                buildExecuteKieSession(List.of(
+                        FeatureFlag.builder().flagName("privatelaw_wa_1_0").status(false).build(),
+                        FeatureFlag.builder().flagName("privatelaw_wa_1_1").status(false).build(),
+                        FeatureFlag.builder().flagName("privatelaw_wa_1_2").status(false).build(),
+                        FeatureFlag.builder().flagName("privatelaw_wa_1_3").status(false).build()));
 
         //assertions
         assertTrue(roleAssignments.isEmpty());
+    }
+
+    List<FeatureFlag> getFeatureFlags() {
+        return List.of(FeatureFlag.builder().flagName("privatelaw_wa_1_0").status(true).build(),
+                FeatureFlag.builder().flagName("privatelaw_wa_1_1").status(true).build(),
+                FeatureFlag.builder().flagName("privatelaw_wa_1_2").status(true).build(),
+                FeatureFlag.builder().flagName("privatelaw_wa_1_3").status(true).build());
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-147
Retire old rules after PRIVATELAW_WA_1_3 Go Live - Rules privatelaw_judge_org_role & privatelaw_judge_org_role_for_fee_paid_judge removed as obsolete, Test refactored

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
