### PR TITLE
DTSAM-154 CVE-2024-25710 Fix commons-compress upgraded to 1.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -414,7 +414,7 @@ dependencies {
     implementation 'commons-io:commons-io:20030203.000550'
     //CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090
     // To be cleaned up later
-    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.21'
+    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: versions.tomcat
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcat
 

--- a/build.gradle
+++ b/build.gradle
@@ -414,7 +414,7 @@ dependencies {
     implementation 'commons-io:commons-io:20030203.000550'
     //CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090
     // To be cleaned up later
-    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26'
+    implementation group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: versions.tomcat
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcat
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,8 +12,4 @@
         <notes>https://tools.hmcts.net/jira/browse/DTSAM-88 azure</notes>
         <cve>CVE-2023-36052</cve>
     </suppress>
-    <suppress>
-        <notes>https://tools.hmcts.net/jira/browse/DTSAM-154 commons-compress</notes>
-        <cve>CVE-2024-25710</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-154
CVE-2024-25710 Fix commons-compress upgraded to 1.26

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
