### PR TITLE
GA-137 add organisation_last_updated to OrganisationRefreshQueueEntity

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/data/OrganisationRefreshQueueEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/data/OrganisationRefreshQueueEntity.java
@@ -23,6 +23,9 @@ public class OrganisationRefreshQueueEntity {
     @Column(name = "organisation_id", nullable = false)
     private String organisationId;
 
+    @Column(name = "organisation_last_updated", nullable = false)
+    private LocalDateTime organisationLastUpdated;
+
     @Column(name = "last_updated", nullable = false)
     private LocalDateTime lastUpdated;
 

--- a/src/main/resources/db/migration/V20240104_49__GA-49_Create_organisation_refresh_queue_table.sql
+++ b/src/main/resources/db/migration/V20240104_49__GA-49_Create_organisation_refresh_queue_table.sql
@@ -1,6 +1,7 @@
 CREATE TABLE organisation_refresh_queue (
     organisation_id text PRIMARY KEY,
-    last_updated timestamp without time zone NOT NULL,
+    organisation_last_updated timestamp without time zone NOT NULL,
+    last_updated timestamp without time zone NOT NULL default now(),
     access_types_min_version integer NOT NULL,
     active bool NOT NULL,
     retry integer default 0,


### PR DESCRIPTION
### Jira link (if applicable)

[GA-137](https://tools.hmcts.net/jira/browse/GA-137)

### Change description ###

* Add `organisation_last_updated` column
* Default the `last_updated` column to the current time