### PR TITLE
DTSAM-185 CVE-2024-1597 postgresql upgraded to 42.6.1, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -407,7 +407,7 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.8'
     implementation group: 'org.apache.maven', name: 'maven-core', version: '3.8.7'
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.6.1'
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,8 +12,4 @@
         <notes>https://tools.hmcts.net/jira/browse/DTSAM-88 azure</notes>
         <cve>CVE-2023-36052</cve>
     </suppress>
-    <suppress>
-        <notes>https://tools.hmcts.net/jira/browse/DTSAM-185 postgresql_jdbc_driver</notes>
-        <cve>CVE-2024-1597</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-185
CVE-2024-1597 postgresql upgraded to 42.6.1, suppression removed

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
