### PR TITLE
AM-2936 TEST PR for PR-1689: Test with JBS subchart disabled

### DIFF
--- a/charts/am-org-role-mapping-service/values.preview.template.yaml
+++ b/charts/am-org-role-mapping-service/values.preview.template.yaml
@@ -71,8 +71,9 @@ java:
 orm:
   ras:
     enabled: true
+  ## AM-2936: temp disable to proved subchart conditions work
   jbs:
-    enabled: true
+    enabled: false
   servicebus:
     enabled: true
 


### PR DESCRIPTION
### Jira link (if applicable)

   [AM-2936](https://tools.hmcts.net/jira/browse/AM-2936) _"Pipeline improvements: reconfigure ORM PREVIEW chart to use an independent version of RAS and JBS"_

### Change description ###

Test of #1689 / #1855 with JBS subchart disabled.

> NB: This PR is a TEST for #1689 / #1855.
> see also: 
> * #1860
> * #1861

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - **NO**
