### PR TITLE
DTSAM-261 verify PREVIEW RAS and JBS are healthy

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -12,6 +12,7 @@ properties(
 @Library("Infrastructure")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
+import uk.gov.hmcts.contino.HealthChecker
 
 def type = "java"
 def product = "am"
@@ -123,6 +124,11 @@ withPipeline(type, product, component) {
 
   before('functionalTest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/tests/integration/**/*'
+
+    // check the extra RAS and JBS instances are up in PREVIEW for this PR
+    def healthChecker = new HealthChecker(this)
+    healthChecker.check("$ROLE_ASSIGNMENT_URL/health", 10, 40)
+    healthChecker.check("$JUDICIAL_BOOKING_URL/health", 10, 40)
   }
 
   afterAlways('functionalTest:preview') {


### PR DESCRIPTION
### Jira link (if applicable)

   [DTSAM-261](https://tools.hmcts.net/jira/browse/DTSAM-261) _"Update ORM jenkins steps to include verification that PREVIEW RAS and JBS is available before starting functional tests"_

### Change description ###

Verify PREVIEW RAS and JBS are healthy before running FTAs.

> NB: see test PRs: 
> * #1867
> * #1868

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - **NO**
