### PR TITLE
DTSAM-246 Retire old rules after PRIVATELAW_WA_1_4 Go Live - removed …

### DIFF
--- a/src/main/resources/validationrules/privatelaw/privatelaw-other-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-other-mapping.drl
@@ -16,35 +16,6 @@ import function uk.gov.hmcts.reform.orgrolemapping.domain.service.RequestMapping
 import function uk.gov.hmcts.reform.orgrolemapping.util.UtilityFunctions.getJurisdictionFromServiceCode;
 
 /*
- * Private Law "listed-hearing-viewer" Org role mapping.
- * Made obsolete in DTSAM-182 by PRIVATELAW_WA_1_4.
- * To be removed in DTSAM-246.
- */
-rule "private_law_cymru_caseworker_hearing_viewer_other_gov_dept"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_2.getValue())
-  $f2: FeatureFlag(status == false, flagName == FeatureFlagEnum.PRIVATELAW_WA_1_4.getValue())
-  $up: CaseWorkerAccessProfile(roleId in ("18"), serviceCode in ("ABA5"), !suspended)
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode(getJurisdictionFromServiceCode($up.getServiceCode())));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($up.getId())
-      .roleCategory(RoleCategory.OTHER_GOV_DEPT)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("listed-hearing-viewer")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .attributes(attribute)
-      .build());
-      logMsg("Rule : private_law_cymru_caseworker_hearing_viewer_other_gov_dept");
-end;
-
-/*
  * Private Law "caseworker-privatelaw-externaluser-viewonly" Org role mapping.
  */
 rule "private_law_caseworker_externaluser_viewonly_other_gov_dept"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-246
Retire old rules after PRIVATELAW_WA_1_4 Go Live - removed rule private_law_cymru_caseworker_hearing_viewer_other_gov_dept from privatelaw-other-mapping.drl


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
