### PR TITLE
DTSAM-336 Test PR for broken CRD integration but without FTA skip 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -86,7 +86,7 @@ env.PACT_BROKER_PORT = "443"
 env.PACT_BROKER_SCHEME = "https"
 
 // Turn off FTAs if RD is unavailable, DTSAM-336
-env.JUDICIAL_FTA_ENABLED = "true"
+env.JUDICIAL_FTA_ENABLED = "false"
 env.CASEWORKER_FTA_ENABLED = "true"
 
 // Var to turn FTA on for azure-messaging-servicebus DTSAM-150

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -86,7 +86,7 @@ env.PACT_BROKER_PORT = "443"
 env.PACT_BROKER_SCHEME = "https"
 
 // Turn off FTAs if RD is unavailable, DTSAM-336
-env.JUDICIAL_FTA_ENABLED = "false"
+env.JUDICIAL_FTA_ENABLED = "false" // temporarily disabled DTSAM-334
 env.CASEWORKER_FTA_ENABLED = "true"
 
 // Var to turn FTA on for azure-messaging-servicebus DTSAM-150

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -85,6 +85,10 @@ env.PACT_BROKER_URL = "pact-broker.platform.hmcts.net"
 env.PACT_BROKER_PORT = "443"
 env.PACT_BROKER_SCHEME = "https"
 
+// Turn off FTAs if RD is unavailable, DTSAM-336
+env.JUDICIAL_FTA_ENABLED = "true"
+env.CASEWORKER_FTA_ENABLED = "true"
+
 // Var to turn FTA on for azure-messaging-servicebus DTSAM-150
 env.AZURE_SERVICE_BUS_FTA_ENABLED = "true"
 env.REFRESH_FTA_ENABLED = "true"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -84,7 +84,7 @@ env.AZURE_SERVICE_BUS_FTA_ENABLED = "true"
 // Don't run refresh FTAs on AAT DTSAM-173
 env.REFRESH_FTA_ENABLED = "false"
 // Turn off FTAs if RD is unavailable, DTSAM-336
-env.JUDICIAL_FTA_ENABLED = "true"
+env.JUDICIAL_FTA_ENABLED = "false"
 env.CASEWORKER_FTA_ENABLED = "true"
 
   overrideVaultEnvironments(vaultOverrides)

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -83,6 +83,9 @@ env.JUDICIAL_BOOKING_URL = "http://am-judicial-booking-service-aat.service.core-
 env.AZURE_SERVICE_BUS_FTA_ENABLED = "true"
 // Don't run refresh FTAs on AAT DTSAM-173
 env.REFRESH_FTA_ENABLED = "false"
+// Turn off FTAs if RD is unavailable, DTSAM-336
+env.JUDICIAL_FTA_ENABLED = "true"
+env.CASEWORKER_FTA_ENABLED = "true"
 
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -79,13 +79,15 @@ env.TEST_URL = "http://am-org-role-mapping-service-aat.service.core-compute-aat.
 env.LAUNCH_DARKLY_ENV = "aat"
 env.JUDICIAL_BOOKING_URL = "http://am-judicial-booking-service-aat.service.core-compute-aat.internal"
 
+// Turn off FTAs if RD is unavailable, DTSAM-336
+env.JUDICIAL_FTA_ENABLED = "false" // temporarily disabled DTSAM-334
+env.CASEWORKER_FTA_ENABLED = "true"
+
 // Var to turn FTA on for azure-messaging-servicebus DTSAM-150
 env.AZURE_SERVICE_BUS_FTA_ENABLED = "true"
+
 // Don't run refresh FTAs on AAT DTSAM-173
 env.REFRESH_FTA_ENABLED = "false"
-// Turn off FTAs if RD is unavailable, DTSAM-336
-env.JUDICIAL_FTA_ENABLED = "false"
-env.CASEWORKER_FTA_ENABLED = "true"
 
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)

--- a/charts/am-org-role-mapping-service/values.preview.template.yaml
+++ b/charts/am-org-role-mapping-service/values.preview.template.yaml
@@ -36,7 +36,8 @@ java:
     S2S_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     ROLE_ASSIGNMENT_APP_URL: "http://{{ .Release.Name }}-am-role-assignment-service"
     JUDICIAL_BOOKING_APP_URL: "http://{{ .Release.Name }}-am-judicial-booking-service"
-    CASE_WORKER_REF_APP_URL: http://rd-caseworker-ref-api-aat.service.core-compute-aat.internal
+    # DTSAM-336 temp misconfigure: CASE_WORKER_REF_APP_URL: http://rd-caseworker-ref-api-aat.service.core-compute-aat.internal
+    CASE_WORKER_REF_APP_URL: http://rd-caseworker-ref-api-aat-bad-url.service.core-compute-aat.internal
     JUDICIAL_REF_APP_URL: http://rd-judicial-api-aat.service.core-compute-aat.internal
     LAUNCH_DARKLY_ENV: pr
     AMQP_SHARED_ACCESS_KEY_NAME: RootManageSharedAccessKey

--- a/src/functionalTest/resources/features/F-001/F-001.feature
+++ b/src/functionalTest/resources/features/F-001/F-001.feature
@@ -1,4 +1,4 @@
-@F-001
+@F-001 @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
 Feature: F-001 :Create Role Assignments for Caseworker Users
 
   Background:

--- a/src/functionalTest/resources/features/F-002/F-002.feature
+++ b/src/functionalTest/resources/features/F-002/F-002.feature
@@ -5,6 +5,7 @@ Feature:F-002: Refresh Role Assignments for CRD and JRD users
     Given an appropriate test context as detailed in the test data source
 
    @S-011
+   @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
    @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
    Scenario: must successfully refresh staff user org roles for a job
      Given a user with [an active IDAM profile with full permissions],
@@ -23,6 +24,7 @@ Feature:F-002: Refresh Role Assignments for CRD and JRD users
      And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-011_DeleteDataForRoleAssignments].
 
   @S-012
+  @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
   Scenario: must successfully refresh judicial user org roles for a job
     Given a user with [an active IDAM profile with full permissions],

--- a/src/functionalTest/resources/features/F-003/F-003.feature
+++ b/src/functionalTest/resources/features/F-003/F-003.feature
@@ -1,10 +1,11 @@
-@F-003
+@F-003 @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
 Feature: F-003 : Create Role Assignments for Judicial Users
 
   Background:
     Given an appropriate test context as detailed in the test data source
 
-  @S-022 @FeatureToggle(LD:orm-jrd-org-role=on) @FeatureToggle(DB:sscs_hearing_1_0=on)
+  @S-022
+  @FeatureToggle(LD:orm-jrd-org-role=on) @FeatureToggle(DB:sscs_hearing_1_0=on)
   Scenario: must successfully create judicial role mapping for Tribunal Judge - fee paid appointment.
      Given a user with [an active IDAM profile with full permissions],
      And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-022_DeleteDataForRoleAssignments01],
@@ -17,7 +18,8 @@ Feature: F-003 : Create Role Assignments for Judicial Users
      And the response has all other details as expected,
      And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-022_DeleteDataForRoleAssignments01].
 
-  @S-023 @FeatureToggle(LD:orm-jrd-org-role=on)
+  @S-023
+  @FeatureToggle(LD:orm-jrd-org-role=on)
   Scenario: must successfully create judicial role mapping for Tribunal Judge - salaried appointment.
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-023_DeleteDataForRoleAssignments01],

--- a/src/functionalTest/resources/features/F-004/F-004.feature
+++ b/src/functionalTest/resources/features/F-004/F-004.feature
@@ -1,10 +1,12 @@
-@F-004
+@F-004 @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
 Feature: F-004 : Refresh Role Assignments for Judicial Users
 
   Background:
     Given an appropriate test context as detailed in the test data source
 
-  @S-031 @FeatureToggle(LD:orm-judicial-refresh-role-api=on) @FeatureToggle(LD:jbs-create-bookings-api-flag=on) @FeatureToggle(LD:jbs-query-bookings-api-flag=on)
+  @S-031
+  @FeatureToggle(LD:orm-judicial-refresh-role-api=on) @FeatureToggle(LD:jbs-create-bookings-api-flag=on)
+  @FeatureToggle(LD:jbs-query-bookings-api-flag=on)
   Scenario: must successfully create judicial role assignments for a user having single judicial booking
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-031_DeleteDataForRoleAssignments]
@@ -19,7 +21,9 @@ Feature: F-004 : Refresh Role Assignments for Judicial Users
     And the response has all other details as expected,
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-031_DeleteDataForRoleAssignments].
 
-  @S-032 @FeatureToggle(LD:orm-judicial-refresh-role-api=on) @FeatureToggle(LD:jbs-create-bookings-api-flag=on) @FeatureToggle(LD:jbs-query-bookings-api-flag=on)
+  @S-032
+  @FeatureToggle(LD:orm-judicial-refresh-role-api=on) @FeatureToggle(LD:jbs-create-bookings-api-flag=on)
+  @FeatureToggle(LD:jbs-query-bookings-api-flag=on)
   Scenario: must successfully create judicial role mappings for User having multiple Judicial bookings
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-032_DeleteDataForRoleAssignments]
@@ -35,7 +39,9 @@ Feature: F-004 : Refresh Role Assignments for Judicial Users
     And the response has all other details as expected,
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-032_DeleteDataForRoleAssignments].
 
-  @S-033 @FeatureToggle(LD:orm-judicial-refresh-role-api=on) @FeatureToggle(LD:jbs-create-bookings-api-flag=on) @FeatureToggle(LD:jbs-query-bookings-api-flag=on)
+  @S-033
+  @FeatureToggle(LD:orm-judicial-refresh-role-api=on) @FeatureToggle(LD:jbs-create-bookings-api-flag=on)
+  @FeatureToggle(LD:jbs-query-bookings-api-flag=on)
   Scenario: must successfully create judicial role mappings for User having no judicial booking
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-033_DeleteDataForRoleAssignments]

--- a/src/functionalTest/resources/features/F-005/F-005.feature
+++ b/src/functionalTest/resources/features/F-005/F-005.feature
@@ -5,7 +5,7 @@ Feature: F-005 : Create Role Assignments for Hearing Roles
     Given an appropriate test context as detailed in the test data source
 
   @S-041
-  @FeatureToggle(DB:sscs_wa_1_2=on)
+  @FeatureToggle(DB:sscs_wa_1_2=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for listed-hearing-viewer
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-041_DeleteDataForRoleAssignments]
@@ -17,6 +17,7 @@ Feature: F-005 : Create Role Assignments for Hearing Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-041_DeleteDataForRoleAssignments].
 
   @S-042
+  @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for hearing-viewer and hearing-manager
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-042_DeleteDataForRoleAssignments]
@@ -28,6 +29,7 @@ Feature: F-005 : Create Role Assignments for Hearing Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-042_DeleteDataForRoleAssignments].
 
   @S-043
+  @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for admin and legal operation role assignments
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-043_DeleteDataForRoleAssignments]
@@ -40,6 +42,7 @@ Feature: F-005 : Create Role Assignments for Hearing Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-043_DeleteDataForRoleAssignments].
 
   @S-044
+  @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for SSCS admin and legal operation role assignments with multiple regions
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-044_DeleteDataForRoleAssignments]
@@ -52,7 +55,7 @@ Feature: F-005 : Create Role Assignments for Hearing Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-044_DeleteDataForRoleAssignments].
 
   @S-045
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for hearing-viewer
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-045_DeleteDataForRoleAssignments]

--- a/src/functionalTest/resources/features/F-006/F-006.feature
+++ b/src/functionalTest/resources/features/F-006/F-006.feature
@@ -5,7 +5,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     Given an appropriate test context as detailed in the test data source
 
   @S-051
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for tribunal-caseworker and registrar
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-051_DeleteDataForRoleAssignments]
@@ -17,7 +17,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-051_DeleteDataForRoleAssignments].
 
   @S-052
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for super-user and clerk
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-052_DeleteDataForRoleAssignments]
@@ -29,7 +29,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-052_DeleteDataForRoleAssignments].
 
   @S-053
-  @FeatureToggle(DB:sscs_wa_1_2=on)
+  @FeatureToggle(DB:sscs_wa_1_2=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create organisational role mapping for dwp and hmrc
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-053_DeleteDataForRoleAssignments]
@@ -41,7 +41,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-053_DeleteDataForRoleAssignments].
 
   @S-054
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Senior Legal Caseworker
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-054_DeleteDataForRoleAssignments],
@@ -54,7 +54,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-054_DeleteDataForRoleAssignments].
 
   @S-055
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Hearing Centre Team Leader and Hearing Centre Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-055_DeleteDataForRoleAssignments],
@@ -68,7 +68,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-055_DeleteDataForRoleAssignments].
 
   @S-056
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Regional Centre Team Leader and Regional Centre Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-056_DeleteDataForRoleAssignments],
@@ -82,7 +82,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-056_DeleteDataForRoleAssignments].
 
   @S-057
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC Team Leader and CTSC Admin
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-057_DeleteDataForRoleAssignments],
@@ -96,7 +96,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-057_DeleteDataForRoleAssignments].
 
   @S-058
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Tribunal Judge - Salaried appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-058_DeleteDataForRoleAssignments],
@@ -110,7 +110,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-058_DeleteDataForRoleAssignments].
 
   @S-059
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Tribunal Judge - Fee Paid appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-059_DeleteDataForRoleAssignments],
@@ -124,7 +124,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-059_DeleteDataForRoleAssignments].
 
    @S-060
-   @FeatureToggle(DB:sscs_wa_1_0=on)
+   @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
    Scenario: must successfully create judicial role mapping for Tribunal Member Disability - Fee Paid appointment
      Given a user with [an active IDAM profile with full permissions],
      And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-060_DeleteDataForRoleAssignments],
@@ -138,7 +138,7 @@ Feature: F-006 : Create Role Assignments for SSCS Staff and Judicial Org Roles
      And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-060_DeleteDataForRoleAssignments].
 
   @S-161
-  @FeatureToggle(DB:sscs_wa_1_0=on)
+  @FeatureToggle(DB:sscs_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for President of Tribunal - Salaried appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-161_DeleteDataForRoleAssignments],

--- a/src/functionalTest/resources/features/F-007/F-007.feature
+++ b/src/functionalTest/resources/features/F-007/F-007.feature
@@ -5,7 +5,7 @@ Feature: F-007 :Create Role Assignments for CIVIL Caseworker and Judicial Users
     Given an appropriate test context as detailed in the test data source
 
   @S-061
-  @FeatureToggle(DB:civil_wa_1_1=on)
+  @FeatureToggle(DB:civil_wa_1_1=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for National Business Centre Team Leader
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-061_DeleteDataForRoleAssignments],
@@ -18,7 +18,7 @@ Feature: F-007 :Create Role Assignments for CIVIL Caseworker and Judicial Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-061_DeleteDataForRoleAssignments].
 
   @S-062
-  @FeatureToggle(DB:civil_wa_1_0=on)
+  @FeatureToggle(DB:civil_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Hearing Centre Team Leader and Hearing Centre Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-062_DeleteDataForRoleAssignments],
@@ -32,7 +32,7 @@ Feature: F-007 :Create Role Assignments for CIVIL Caseworker and Judicial Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-062_DeleteDataForRoleAssignments].
 
   @S-063
-  @FeatureToggle(DB:civil_wa_1_4=on)
+  @FeatureToggle(DB:civil_wa_1_4=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Tribunal Caseworker
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-063_DeleteDataForRoleAssignments],
@@ -45,7 +45,7 @@ Feature: F-007 :Create Role Assignments for CIVIL Caseworker and Judicial Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-063_DeleteDataForRoleAssignments].
 
   @S-064
-  @FeatureToggle(DB:civil_wa_1_0=on)
+  @FeatureToggle(DB:civil_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-061_DeleteDataForRoleAssignments],
@@ -58,7 +58,7 @@ Feature: F-007 :Create Role Assignments for CIVIL Caseworker and Judicial Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-061_DeleteDataForRoleAssignments].
 
   @S-081
-  @FeatureToggle(DB:civil_wa_1_0=on)
+  @FeatureToggle(DB:civil_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Judge
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-081_DeleteDataForRoleAssignments],
@@ -71,7 +71,7 @@ Feature: F-007 :Create Role Assignments for CIVIL Caseworker and Judicial Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-081_DeleteDataForRoleAssignments].
 
   @S-082
-  @FeatureToggle(DB:civil_wa_1_1=on)
+  @FeatureToggle(DB:civil_wa_1_1=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for circuit Judge
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-082_DeleteDataForRoleAssignments],
@@ -84,7 +84,7 @@ Feature: F-007 :Create Role Assignments for CIVIL Caseworker and Judicial Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-082_DeleteDataForRoleAssignments].
 
   @S-084
-  @FeatureToggle(DB:civil_wa_1_0=on)
+  @FeatureToggle(DB:civil_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for fee paid Judge
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-084_DeleteDataForRoleAssignments],

--- a/src/functionalTest/resources/features/F-008/F-008.feature
+++ b/src/functionalTest/resources/features/F-008/F-008.feature
@@ -5,7 +5,7 @@ Feature: F-008 : Create Role Assignments for PrivateLaw Caseworker and Judicial 
     Given an appropriate test context as detailed in the test data source
 
   @S-071
-  @FeatureToggle(DB:privatelaw_wa_1_1=on)
+  @FeatureToggle(DB:privatelaw_wa_1_1=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Legal Caseworker and Senior Legal Caseworker
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-071_DeleteDataForRoleAssignments],
@@ -20,7 +20,7 @@ Feature: F-008 : Create Role Assignments for PrivateLaw Caseworker and Judicial 
 
 
   @S-072
-  @FeatureToggle(DB:privatelaw_wa_1_0=on)
+  @FeatureToggle(DB:privatelaw_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Hearing Centre Team Leader and Hearing Centre Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-072_DeleteDataForRoleAssignments],
@@ -35,7 +35,7 @@ Feature: F-008 : Create Role Assignments for PrivateLaw Caseworker and Judicial 
 
 
   @S-073
-  @FeatureToggle(DB:privatelaw_wa_1_0=on)
+  @FeatureToggle(DB:privatelaw_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Deputy Circuit Judge - fee-paid appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-073_DeleteDataForRoleAssignments],
@@ -50,7 +50,7 @@ Feature: F-008 : Create Role Assignments for PrivateLaw Caseworker and Judicial 
 
 
   @S-074
-  @FeatureToggle(DB:privatelaw_wa_1_0=on)
+  @FeatureToggle(DB:privatelaw_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for District Judge - salaried appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-074_DeleteDataForRoleAssignments],

--- a/src/functionalTest/resources/features/F-009/F-009.feature
+++ b/src/functionalTest/resources/features/F-009/F-009.feature
@@ -5,7 +5,7 @@ Feature: F-009 : Create Role Assignments for PublicLaw Caseworker and Judicial U
     Given an appropriate test context as detailed in the test data source
 
   @S-091
-  @FeatureToggle(DB:publiclaw_wa_1_0=on)
+  @FeatureToggle(DB:publiclaw_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Legal Caseworker and Senior Legal Caseworker
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-091_DeleteDataForRoleAssignments],
@@ -19,7 +19,7 @@ Feature: F-009 : Create Role Assignments for PublicLaw Caseworker and Judicial U
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-091_DeleteDataForRoleAssignments].
 
   @S-092
-  @FeatureToggle(DB:publiclaw_wa_1_0=on)
+  @FeatureToggle(DB:publiclaw_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Hearing Centre Team Leader and Hearing Centre Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-092_DeleteDataForRoleAssignments],
@@ -33,7 +33,7 @@ Feature: F-009 : Create Role Assignments for PublicLaw Caseworker and Judicial U
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-092_DeleteDataForRoleAssignments].
 
   @S-093
-  @FeatureToggle(DB:publiclaw_wa_1_0=on)
+  @FeatureToggle(DB:publiclaw_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC Team Leader and CTSC Admin
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-093_DeleteDataForRoleAssignments],
@@ -47,7 +47,7 @@ Feature: F-009 : Create Role Assignments for PublicLaw Caseworker and Judicial U
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-093_DeleteDataForRoleAssignments].
 
   @S-094
-  @FeatureToggle(DB:publiclaw_wa_1_0=on)
+  @FeatureToggle(DB:publiclaw_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Deputy District Judge - Fee-Paid appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-094_DeleteDataForRoleAssignments],
@@ -61,7 +61,7 @@ Feature: F-009 : Create Role Assignments for PublicLaw Caseworker and Judicial U
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-094_DeleteDataForRoleAssignments].
 
   @S-095
-  @FeatureToggle(DB:publiclaw_wa_1_0=on)
+  @FeatureToggle(DB:publiclaw_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Designated Family Judge - Salaried appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-095_DeleteDataForRoleAssignments],
@@ -73,4 +73,4 @@ Feature: F-009 : Create Role Assignments for PublicLaw Caseworker and Judicial U
     Then a positive response is received,
     And the response has all other details as expected
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-095_DeleteDataForRoleAssignments].
-
+    

--- a/src/functionalTest/resources/features/F-010/F-010.feature
+++ b/src/functionalTest/resources/features/F-010/F-010.feature
@@ -5,7 +5,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     Given an appropriate test context as detailed in the test data source
 
   @S-101
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Legal Caseworker and Senior Legal Caseworker
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-101_DeleteDataForRoleAssignments],
@@ -19,7 +19,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-101_DeleteDataForRoleAssignments].
 
   @S-102
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Hearing Centre Team Leader and Hearing Centre Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-102_DeleteDataForRoleAssignments],
@@ -33,7 +33,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-102_DeleteDataForRoleAssignments].
 
   @S-103
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC Team Leader and CTSC Admin
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-103_DeleteDataForRoleAssignments],
@@ -47,7 +47,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-103_DeleteDataForRoleAssignments].
 
   @S-104
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Regional Centre Team Leader and Regional Centre Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-104_DeleteDataForRoleAssignments],
@@ -61,7 +61,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-104_DeleteDataForRoleAssignments].
 
   @S-105
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for Court Clerk
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-105_DeleteDataForRoleAssignments],
@@ -74,7 +74,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-105_DeleteDataForRoleAssignments].
 
   @S-106
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Regional Employment Judge - Salaried appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-106_DeleteDataForRoleAssignments],
@@ -88,7 +88,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-106_DeleteDataForRoleAssignments].
 
   @S-107
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Employment Judge - Fee Paid appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-107_DeleteDataForRoleAssignments],
@@ -102,7 +102,7 @@ Feature: F-010 : Create Role Assignments for EmploymentTribunal Caseworker and J
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-107_DeleteDataForRoleAssignments].
 
   @S-108
-  @FeatureToggle(DB:employment_wa_1_0=on)
+  @FeatureToggle(DB:employment_wa_1_0=on) @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   Scenario: must successfully create judicial role mapping for Tribunal Member - Fee Paid appointment
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-108_DeleteDataForRoleAssignments],

--- a/src/functionalTest/resources/features/F-011/F-011.feature
+++ b/src/functionalTest/resources/features/F-011/F-011.feature
@@ -5,6 +5,7 @@ Feature: F-011 : Verify CRD and JRD service bus messages
     Given an appropriate test context as detailed in the test data source
 
   @S-211
+  @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   @FeatureToggle(EV:AZURE_SERVICE_BUS_FTA_ENABLED=on) @FeatureToggle(DB:employment_wa_1_0=on)
   Scenario: must successfully create org role mapping for Legal Caseworker and Senior Legal Caseworker
     Given a user with [an active IDAM profile with full permissions],
@@ -20,6 +21,7 @@ Feature: F-011 : Verify CRD and JRD service bus messages
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-211_DeleteDataForRoleAssignments].
 
   @S-213
+  @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
   @FeatureToggle(EV:AZURE_SERVICE_BUS_FTA_ENABLED=on) @FeatureToggle(DB:employment_wa_1_0=on)
   Scenario: must successfully create judicial role mapping for Tribunal Member - Fee Paid appointment
     Given a user with [an active IDAM profile with full permissions],


### PR DESCRIPTION
### Jira link (if applicable)

   [DTSAM-336](https://tools.hmcts.net/jira/browse/DTSAM-336) _"ORM FTAs may fail if Ref-Data services are unavailable. Add EV flag option to disable those FTAs if needed"_

### Change description ###

This a test PRs for #1943. Scenario is: **broken CRD integration but _without_ FTA skip**.

> NB: other test PRs:
> * #1945
> * #1946
> * #1947

### Checklist

- [x] Does this PR introduce a breaking change - **NO**
