### PR TITLE
DTSAM-318 FTAs for RefreshJob validation

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -35,7 +35,8 @@ def vaultOverrides = [
 def secrets = [
     's2s-${env}': [
       secret('microservicekey-am-org-role-mapping-service', 'BEFTA_S2S_CLIENT_SECRET'),
-      secret('microservicekey-am-org-role-mapping-service', 'AM_ORG_ROLE_MAPPING_SERVICE_SECRET')
+      secret('microservicekey-am-org-role-mapping-service', 'AM_ORG_ROLE_MAPPING_SERVICE_SECRET'),
+      secret('microservicekey-xui-webapp', 'XUI_WEBAPP_S2S_SECRET')
     ],
     'am-${env}': [
       secret('orm-IDAM-CLIENT-ID', 'ORM_IDAM_CLIENT_ID'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -34,7 +34,8 @@ def vaultOverrides = [
 def secrets = [
     's2s-${env}': [
       secret('microservicekey-am-org-role-mapping-service', 'BEFTA_S2S_CLIENT_SECRET'),
-      secret('microservicekey-am-org-role-mapping-service', 'AM_ORG_ROLE_MAPPING_SERVICE_SECRET')
+      secret('microservicekey-am-org-role-mapping-service', 'AM_ORG_ROLE_MAPPING_SERVICE_SECRET'),
+      secret('microservicekey-xui-webapp', 'XUI_WEBAPP_S2S_SECRET')
     ],
     'am-${env}': [
       secret('orm-IDAM-CLIENT-ID', 'ORM_IDAM_CLIENT_ID'),

--- a/src/functionalTest/java/uk/gov/hmcts/reform/orgrolemapping/befta/OrgRoleMappingAmTestAutomationAdapter.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/orgrolemapping/befta/OrgRoleMappingAmTestAutomationAdapter.java
@@ -70,6 +70,8 @@ public class OrgRoleMappingAmTestAutomationAdapter extends DefaultTestAutomation
                 return LocalDate.now().plusDays(1);
             case ("generateS2STokenForOrm"):
                 return new TokenUtils().generateServiceToken(buildOrmSpecificConfig());
+            case ("generateS2STokenForXui"):
+                return new TokenUtils().generateServiceToken(buildXuiSpecificConfig());
             default:
                 return super.calculateCustomValue(scenarioContext, key);
         }
@@ -82,4 +84,13 @@ public class OrgRoleMappingAmTestAutomationAdapter extends DefaultTestAutomation
         config.setS2sUrl(EnvironmentVariableUtils.getRequiredVariable("IDAM_S2S_URL"));
         return config;
     }
+
+    private UserTokenProviderConfig buildXuiSpecificConfig() {
+        UserTokenProviderConfig config = new UserTokenProviderConfig();
+        config.setMicroService("xui_webapp");
+        config.setSecret(System.getenv("XUI_WEBAPP_S2S_SECRET"));
+        config.setS2sUrl(EnvironmentVariableUtils.getRequiredVariable("IDAM_S2S_URL"));
+        return config;
+    }
+
 }

--- a/src/functionalTest/resources/features/F-002/F-002.feature
+++ b/src/functionalTest/resources/features/F-002/F-002.feature
@@ -46,7 +46,7 @@ Feature:F-002: Refresh Role Assignments for CRD and JRD users
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to insert new job in ORM DB to initiate Refresh process] as in [S-014_InsertJobForRefreshAPI],
     And a successful call [to delete job details from ORM DB] as in [S-014_DeleteJobFromORMDB],
-    And the request [contains an existing job details],
+    And the request [contains a reference to the Job that was just deleted],
     When a request is prepared with appropriate values,
     And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
     Then a negative response is received,

--- a/src/functionalTest/resources/features/F-002/F-002.feature
+++ b/src/functionalTest/resources/features/F-002/F-002.feature
@@ -4,24 +4,23 @@ Feature:F-002: Refresh Role Assignments for CRD and JRD users
   Background:
     Given an appropriate test context as detailed in the test data source
 
-   @S-011
-   @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
-   @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
-   Scenario: must successfully refresh staff user org roles for a job
-     Given a user with [an active IDAM profile with full permissions],
-     And a successful call [to insert new job in ORM DB to initiate Refresh process] as in [S-011_InsertJobForRefreshAPI],
-     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-011_DeleteDataForRoleAssignments]
-     And the request [contains an existing job details],
-     When a request is prepared with appropriate values,
-     And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
-     Then a positive response is received,
-     And the response has all other details as expected,
-     And a wait time of [10] seconds [to allow for service bus to process the request],
-     And a successful call [to fetch job details from ORM DB to validate Refresh process] as in [S-011_FetchJobDetailsFromORM],
-     And a successful call [to delete job details from ORM DB] as in [S-011_DeleteJobFromORMDB],
-     And a successful call [to fetch role assignments from Role Assignment Service] as in [S-011_FetchRoleAssignments],
-     And the response has all other details as expected,
-     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-011_DeleteDataForRoleAssignments].
+  @S-011
+  @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
+  @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
+  Scenario: must successfully refresh staff user org roles for a job
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to insert new job in ORM DB to initiate Refresh process] as in [S-011_InsertJobForRefreshAPI],
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-011_DeleteDataForRoleAssignments],
+    And the request [contains an existing job details],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
+    Then a positive response is received,
+    And the response has all other details as expected,
+    And a wait time of [10] seconds [to allow async call to process the request],
+    And a successful call [to fetch job details from ORM DB to validate Refresh process] as in [S-011_FetchJobDetailsFromORM],
+    And a successful call [to delete job details from ORM DB] as in [S-011_DeleteJobFromORMDB],
+    And a successful call [to fetch role assignments from Role Assignment Service] as in [S-011_FetchRoleAssignments],
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-011_DeleteDataForRoleAssignments].
 
   @S-012
   @FeatureToggle(EV:JUDICIAL_FTA_ENABLED=on)
@@ -29,15 +28,50 @@ Feature:F-002: Refresh Role Assignments for CRD and JRD users
   Scenario: must successfully refresh judicial user org roles for a job
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to insert new job in ORM DB to initiate Refresh process] as in [S-012_InsertJobForRefreshAPI],
-    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-012_DeleteDataForRoleAssignments]
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-012_DeleteDataForRoleAssignments],
     And the request [contains an existing job details],
     When a request is prepared with appropriate values,
     And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
     Then a positive response is received,
     And the response has all other details as expected,
-    And a wait time of [10] seconds [to allow for service bus to process the request],
+    And a wait time of [10] seconds [to allow async call to process the request],
     And a successful call [to fetch job details from ORM DB to validate Refresh process] as in [S-012_FetchJobDetailsFromORM],
     And a successful call [to delete job details from ORM DB] as in [S-012_DeleteJobFromORMDB],
     And a successful call [to fetch role assignments from Role Assignment Service] as in [S-012_FetchRoleAssignments],
-    And the response has all other details as expected,
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-012_DeleteDataForRoleAssignments].
+
+  @S-014
+  @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
+  Scenario: must reject refresh job request if job NOT FOUND
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to insert new job in ORM DB to initiate Refresh process] as in [S-014_InsertJobForRefreshAPI],
+    And a successful call [to delete job details from ORM DB] as in [S-014_DeleteJobFromORMDB],
+    And the request [contains an existing job details],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
+    Then a negative response is received,
+    And the response has all other details as expected.
+
+  @S-015
+  @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
+  Scenario: must reject refresh job request if job status is ABORTED
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to insert an ABORTED refresh job in ORM DB] as in [S-015_InsertJobForRefreshAPI],
+    And the request [contains an existing job details],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
+    Then a negative response is received,
+    And the response has all other details as expected,
+    And a successful call [to delete job details from ORM DB] as in [S-015_DeleteJobFromORMDB].
+
+  @S-016
+  @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
+  Scenario: must reject refresh job request if job status is COMPLETED
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to insert a COMPLETED refresh job in ORM DB] as in [S-016_InsertJobForRefreshAPI],
+    And the request [contains an existing job details],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
+    Then a negative response is received,
+    And the response has all other details as expected,
+    And a successful call [to delete job details from ORM DB] as in [S-016_DeleteJobFromORMDB].

--- a/src/functionalTest/resources/features/F-002/F-002.feature
+++ b/src/functionalTest/resources/features/F-002/F-002.feature
@@ -40,6 +40,19 @@ Feature:F-002: Refresh Role Assignments for CRD and JRD users
     And a successful call [to fetch role assignments from Role Assignment Service] as in [S-012_FetchRoleAssignments],
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [S-012_DeleteDataForRoleAssignments].
 
+  @S-013
+  @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
+  Scenario: must reject refresh job request from non-approved S2S service
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to insert new job in ORM DB to initiate Refresh process]  as in [S-013_InsertJobForRefreshAPI],
+    And the request [contains an existing job details],
+    And the request [uses the xui_webapp S2S token, which is an authorised service for ORM but not for Refresh Job endpoint],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Refresh API] operation of [Organisation Role Mapping],
+    Then a negative response is received,
+    And the response has all other details as expected,
+    And a successful call [to delete job details from ORM DB] as in [S-013_DeleteJobFromORMDB].
+
   @S-014
   @FeatureToggle(orm-refresh-role) @FeatureToggle(EV:REFRESH_FTA_ENABLED=on)
   Scenario: must reject refresh job request if job NOT FOUND

--- a/src/functionalTest/resources/features/F-002/S-013.td.json
+++ b/src/functionalTest/resources/features/F-002/S-013.td.json
@@ -1,0 +1,30 @@
+{
+  "_guid_": "S-013",
+  "title": "must reject refresh job request from non-approved S2S service",
+  "_extends_": "F-002_Test_Data_Base",
+
+  "specs": [
+    "contains an existing job details",
+    "uses the xui_webapp S2S token, which is an authorised service for ORM but not for Refresh Job endpoint"
+  ],
+  "request": {
+    "headers": {
+      "ServiceAuthorization": "${[scenarioContext][customValues][generateS2STokenForXui]}"
+    },
+    "queryParams": {
+      "jobId": "${[scenarioContext][childContexts][S-013_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    },
+    "body": {
+      "userIds" : ["b878398b-c7ae-4f4c-95cc-298ca2d287ac"]
+    }
+  },
+  "expectedResponse": {
+    "_extends_": "common_403_Response",
+    "body" : {
+      "status": 403,
+      "error": "Forbidden",
+      "path": "/am/role-mapping/refresh",
+      "timeStamp": "[[ANYTHING_PRESENT]]"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-013.td.json
+++ b/src/functionalTest/resources/features/F-002/S-013.td.json
@@ -24,7 +24,7 @@
       "status": 403,
       "error": "Forbidden",
       "path": "/am/role-mapping/refresh",
-      "timeStamp": "[[ANYTHING_PRESENT]]"
+      "timestamp": "[[ANYTHING_PRESENT]]"
     }
   }
 }

--- a/src/functionalTest/resources/features/F-002/S-013.td.json
+++ b/src/functionalTest/resources/features/F-002/S-013.td.json
@@ -19,7 +19,7 @@
     }
   },
   "expectedResponse": {
-    "_extends_": "common_403_Response",
+    "_extends_": "Common_403_Response",
     "body" : {
       "status": 403,
       "error": "Forbidden",

--- a/src/functionalTest/resources/features/F-002/S-013_DeleteJobFromORMDB.td.json
+++ b/src/functionalTest/resources/features/F-002/S-013_DeleteJobFromORMDB.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "S-013_DeleteJobFromORMDB",
+  "_extends_": "S-011_DeleteJobFromORMDB",
+
+  "request": {
+    "pathVariables": {
+      "jobId": "${[scenarioContext][parentContext][childContexts][S-013_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-013_InsertJobForRefreshAPI.td.json
+++ b/src/functionalTest/resources/features/F-002/S-013_InsertJobForRefreshAPI.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-013_InsertJobForRefreshAPI",
+  "_extends_": "S-011_InsertJobForRefreshAPI"
+}

--- a/src/functionalTest/resources/features/F-002/S-014.td.json
+++ b/src/functionalTest/resources/features/F-002/S-014.td.json
@@ -3,6 +3,9 @@
   "title": "must reject refresh job request if job NOT FOUND",
   "_extends_": "F-002_Test_Data_Base",
 
+  "specs": [
+    "contains a reference to the Job that was just deleted"
+  ],
   "request": {
     "queryParams": {
       "jobId": "${[scenarioContext][childContexts][S-014_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
@@ -12,12 +15,9 @@
     }
   },
   "expectedResponse": {
-    "_extends_": "Common_422_Response",
+    "_extends_": "ORM_422_Response",
     "body" : {
-      "errorCode": 422,
-      "errorMessage": "Unprocessable Entity",
-      "errorDescription": "Provided refresh job couldn't be retrieved.",
-      "timeStamp": "[[ANYTHING_PRESENT]]"
+      "errorDescription": "Provided refresh job couldn't be retrieved."
     }
   }
 }

--- a/src/functionalTest/resources/features/F-002/S-014.td.json
+++ b/src/functionalTest/resources/features/F-002/S-014.td.json
@@ -1,0 +1,23 @@
+{
+  "_guid_": "S-014",
+  "title": "must reject refresh job request if job NOT FOUND",
+  "_extends_": "F-002_Test_Data_Base",
+
+  "request": {
+    "queryParams": {
+      "jobId": "${[scenarioContext][childContexts][S-014_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    },
+    "body": {
+      "userIds" : ["b878398b-c7ae-4f4c-95cc-298ca2d287ac"]
+    }
+  },
+  "expectedResponse": {
+    "_extends_": "Common_422_Response",
+    "body" : {
+      "errorCode": 422,
+      "errorMessage": "Unprocessable Entity",
+      "errorDescription": "Provided refresh job couldn't be retrieved.",
+      "timeStamp": "[[ANYTHING_PRESENT]]"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-014_DeleteJobFromORMDB.td.json
+++ b/src/functionalTest/resources/features/F-002/S-014_DeleteJobFromORMDB.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "S-014_DeleteJobFromORMDB",
+  "_extends_": "S-011_DeleteJobFromORMDB",
+
+  "request": {
+    "pathVariables": {
+      "jobId": "${[scenarioContext][parentContext][childContexts][S-014_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-014_InsertJobForRefreshAPI.td.json
+++ b/src/functionalTest/resources/features/F-002/S-014_InsertJobForRefreshAPI.td.json
@@ -1,0 +1,4 @@
+{
+  "_guid_": "S-014_InsertJobForRefreshAPI",
+  "_extends_": "S-011_InsertJobForRefreshAPI"
+}

--- a/src/functionalTest/resources/features/F-002/S-015.td.json
+++ b/src/functionalTest/resources/features/F-002/S-015.td.json
@@ -15,12 +15,9 @@
     }
   },
   "expectedResponse": {
-    "_extends_": "Common_422_Response",
+    "_extends_": "ORM_422_Response",
     "body" : {
-      "errorCode": 422,
-      "errorMessage": "Unprocessable Entity",
-      "errorDescription": "Provided refresh job is in an invalid state.",
-      "timeStamp": "[[ANYTHING_PRESENT]]"
+      "errorDescription": "Provided refresh job is in an invalid state."
     }
   }
 }

--- a/src/functionalTest/resources/features/F-002/S-015.td.json
+++ b/src/functionalTest/resources/features/F-002/S-015.td.json
@@ -1,0 +1,26 @@
+{
+  "_guid_": "S-015",
+  "title": "must reject refresh job request if job status is ABORTED",
+  "_extends_": "F-002_Test_Data_Base",
+
+  "specs": [
+    "contains an existing job details"
+  ],
+  "request": {
+    "queryParams": {
+      "jobId": "${[scenarioContext][childContexts][S-015_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    },
+    "body": {
+      "userIds" : ["b878398b-c7ae-4f4c-95cc-298ca2d287ac"]
+    }
+  },
+  "expectedResponse": {
+    "_extends_": "Common_422_Response",
+    "body" : {
+      "errorCode": 422,
+      "errorMessage": "Unprocessable Entity",
+      "errorDescription": "Provided refresh job is in an invalid state.",
+      "timeStamp": "[[ANYTHING_PRESENT]]"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-015_DeleteJobFromORMDB.td.json
+++ b/src/functionalTest/resources/features/F-002/S-015_DeleteJobFromORMDB.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "S-015_DeleteJobFromORMDB",
+  "_extends_": "S-011_DeleteJobFromORMDB",
+
+  "request": {
+    "pathVariables": {
+      "jobId": "${[scenarioContext][parentContext][childContexts][S-015_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-015_InsertJobForRefreshAPI.td.json
+++ b/src/functionalTest/resources/features/F-002/S-015_InsertJobForRefreshAPI.td.json
@@ -1,0 +1,19 @@
+{
+  "_guid_": "S-015_InsertJobForRefreshAPI",
+  "_extends_": "S-011_InsertJobForRefreshAPI",
+
+  "specs": [
+    "to insert an ABORTED refresh job in ORM DB"
+  ],
+
+  "request": {
+    "queryParams": {
+      "status" : "ABORTED"
+    }
+  },
+  "expectedResponse": {
+    "body": {
+      "status" : "ABORTED"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-016.td.json
+++ b/src/functionalTest/resources/features/F-002/S-016.td.json
@@ -15,12 +15,9 @@
     }
   },
   "expectedResponse": {
-    "_extends_": "Common_422_Response",
+    "_extends_": "ORM_422_Response",
     "body" : {
-      "errorCode": 422,
-      "errorMessage": "Unprocessable Entity",
-      "errorDescription": "Provided refresh job is in an invalid state.",
-      "timeStamp": "[[ANYTHING_PRESENT]]"
+      "errorDescription": "Provided refresh job is in an invalid state."
     }
   }
 }

--- a/src/functionalTest/resources/features/F-002/S-016.td.json
+++ b/src/functionalTest/resources/features/F-002/S-016.td.json
@@ -1,0 +1,26 @@
+{
+  "_guid_": "S-016",
+  "title": "must reject refresh job request if job status is COMPLETED",
+  "_extends_": "F-002_Test_Data_Base",
+
+  "specs": [
+    "contains an existing job details"
+  ],
+  "request": {
+    "queryParams": {
+      "jobId": "${[scenarioContext][childContexts][S-016_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    },
+    "body": {
+      "userIds" : ["b878398b-c7ae-4f4c-95cc-298ca2d287ac"]
+    }
+  },
+  "expectedResponse": {
+    "_extends_": "Common_422_Response",
+    "body" : {
+      "errorCode": 422,
+      "errorMessage": "Unprocessable Entity",
+      "errorDescription": "Provided refresh job is in an invalid state.",
+      "timeStamp": "[[ANYTHING_PRESENT]]"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-016_DeleteJobFromORMDB.td.json
+++ b/src/functionalTest/resources/features/F-002/S-016_DeleteJobFromORMDB.td.json
@@ -1,0 +1,10 @@
+{
+  "_guid_": "S-016_DeleteJobFromORMDB",
+  "_extends_": "S-011_DeleteJobFromORMDB",
+
+  "request": {
+    "pathVariables": {
+      "jobId": "${[scenarioContext][parentContext][childContexts][S-016_InsertJobForRefreshAPI][testData][actualResponse][body][jobId]}"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/F-002/S-016_InsertJobForRefreshAPI.td.json
+++ b/src/functionalTest/resources/features/F-002/S-016_InsertJobForRefreshAPI.td.json
@@ -1,0 +1,19 @@
+{
+  "_guid_": "S-016_InsertJobForRefreshAPI",
+  "_extends_": "S-011_InsertJobForRefreshAPI",
+
+  "specs": [
+    "to insert a COMPLETED refresh job in ORM DB"
+  ],
+
+  "request": {
+    "queryParams": {
+      "status" : "COMPLETED"
+    }
+  },
+  "expectedResponse": {
+    "body": {
+      "status" : "COMPLETED"
+    }
+  }
+}

--- a/src/functionalTest/resources/features/common/response/ORM_422_Response.td.json
+++ b/src/functionalTest/resources/features/common/response/ORM_422_Response.td.json
@@ -11,6 +11,6 @@
     "errorCode": 422,
     "errorMessage": "Unprocessable Entity",
     "errorDescription": "OVERRIDE_ME",
-    "timeStamp": "[[ANY_TIMESTAMP_NOT_NULLABLE]]"
+    "timeStamp": "[[ANYTHING_PRESENT]]"
   }
 }

--- a/src/functionalTest/resources/features/common/response/ORM_422_Response.td.json
+++ b/src/functionalTest/resources/features/common/response/ORM_422_Response.td.json
@@ -1,0 +1,16 @@
+{
+  "_guid_": "ORM_422_Response",
+  "_extends_": "Common_Response",
+
+  "responseCode": 422,
+  "responseMessage": "Unprocessable Entity",
+  "headers": {
+    "_extends_": "Common_422_Response_Headers"
+  },
+  "body": {
+    "errorCode": 422,
+    "errorMessage": "Unprocessable Entity",
+    "errorDescription": "OVERRIDE_ME",
+    "timeStamp": "[[ANY_TIMESTAMP_NOT_NULLABLE]]"
+  }
+}


### PR DESCRIPTION
### Jira link (if applicable)

   [DTSAM-263](https://tools.hmcts.net/jira/browse/DTSAM-263) _"Updates to allow AM Refreshes to be run unmanned"_
   [DTSAM-318](https://tools.hmcts.net/jira/browse/DTSAM-318) _"AM Refresh Updates: ORM: Refresh Job API"_

### Change description ###

Extend RefreshJob FTAs to include tests for job status.

> NB: This PR contains the FTAs for #1952. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x]  README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - **NO**
