### PR TITLE
DTSAM-571 Test RAS audit of byPassOrgDroolRule

### DIFF
--- a/charts/am-org-role-mapping-service/values.preview.template.yaml
+++ b/charts/am-org-role-mapping-service/values.preview.template.yaml
@@ -80,7 +80,8 @@ orm:
 
 am-role-assignment-service:
   java:
-    image: 'hmctspublic.azurecr.io/am/role-assignment-service:latest'
+    # temporary override to allow test of hmcts/am-role-assignment-service#2364: image: 'hmctspublic.azurecr.io/am/role-assignment-service:latest'
+    image: 'hmctspublic.azurecr.io/am/role-assignment-service:pr-2364'
     imagePullPolicy: Always
     ingressHost: ras-${SERVICE_FQDN}
     releaseNameOverride: "{{ .Release.Name }}-am-role-assignment-service"


### PR DESCRIPTION
### Jira link

[DTSAM-571](https://tools.hmcts.net/jira/browse/DTSAM-571) _"Audit use of `byPassOrgDroolRule`in RAS when receiving ORG roles from ORM"_

### Change description

Temporary override of RAS image name so we can test hmcts/am-role-assignment-service#2364 with data loaded from ORM and the ORM FTAs.

> NB: This is a test PR to test RAS with hmcts/am-role-assignment-service#2364 fix applied.