### PR TITLE
DTSAM-595 Enable 'civil_wa_2_0' ORM flag in PROD

### DIFF
--- a/src/main/resources/db/migration/V20241202_595__DTSAM-595_Enable_civil_wa_2_0_Prod.sql
+++ b/src/main/resources/db/migration/V20241202_595__DTSAM-595_Enable_civil_wa_2_0_Prod.sql
@@ -1,0 +1,2 @@
+-- enable civil_wa_2_0 flag in Prod for: DTSAM-595 / DTSAM-575
+update flag_config set status='true' where flag_name='civil_wa_2_0' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### Jira link

   [DTSAM-595](https://tools.hmcts.net/jira/browse/DTSAM-595) _"Enable 'civil_wa_2_0' ORM flag in PROD"_

### Change description

Enable 'civil_wa_2_0' ORM flag in PROD.

> NB: This is to enabel the changes in PR #2128.