### PR TITLE
DTSAM-536 Enable 'sscs_wa_1_5' ORM flag in PROD

### DIFF
--- a/src/main/resources/db/migration/V20250108_536__DTSAM-536_Enable_sscs_wa_1_5_Prod.sql
+++ b/src/main/resources/db/migration/V20250108_536__DTSAM-536_Enable_sscs_wa_1_5_Prod.sql
@@ -1,0 +1,2 @@
+-- enable sscs_wa_1_5 flag in Prod for: DTSAM-536 / DTSAM-506
+update flag_config set status='true' where flag_name='sscs_wa_1_5' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### Jira link

   [DTSAM-536](https://tools.hmcts.net/jira/browse/DTSAM-536) _"Enable 'sscs_wa_1_5' ORM flag in PROD"_

### Change description

Enable 'sscs_wa_1_5' ORM flag in PROD.

NB: This is to enabel the changes in PR #2084.