### PR TITLE
DTSAM-627 Enable 'iac_wa_1_3' AM ORM flag in PROD

### DIFF
--- a/src/main/resources/db/migration/V20250312_627__DTSAM-627_Enable_iac_wa_1_3_Prod.sql
+++ b/src/main/resources/db/migration/V20250312_627__DTSAM-627_Enable_iac_wa_1_3_Prod.sql
@@ -1,0 +1,2 @@
+-- enable iac_wa_1_3 flag in Prod for: DTSAM-627
+update flag_config set status='true' where flag_name='iac_wa_1_3' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### Jira link

[DTSAM-627](https://tools.hmcts.net/jira/browse/DTSAM-627) _"Enable 'iac_wa_1_3' AM ORM flag in PROD"_

### Change description

Enable 'iac_wa_1_3' AM ORM flag in PROD


> NB: This is to enable the changes in PR #2146.


