### PR TITLE
DTSAM-813 PATCH inital framework for PRM Scheduler Integration Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -548,6 +548,8 @@ dependencies {
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    integrationTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    integrationTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     smokeTestImplementation sourceSets.main.runtimeClasspath
     smokeTestImplementation sourceSets.test.runtimeClasspath
     smokeTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/helper/JsonHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/helper/JsonHelper.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.orgrolemapping.helper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import uk.gov.hmcts.reform.orgrolemapping.controller.utils.WiremockFixtures;
+import uk.gov.hmcts.reform.orgrolemapping.util.JacksonUtils;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static uk.gov.hmcts.reform.orgrolemapping.helper.TestScenarioIntegrationHelper.cloneAndExpandReplaceMap;
+
+public class JsonHelper {
+
+    protected final ObjectMapper mapper = JacksonUtils.MAPPER;
+
+    public String readJsonFromFile(String fileName, Map<String, String> replaceMap) {
+        Map<String, String> replaceMapClone = cloneAndExpandReplaceMap(replaceMap);
+
+        String json = readJsonFromFile(fileName);
+
+        for (Map.Entry<String, String> entry: replaceMapClone.entrySet()) {
+            if (entry.getValue() == null) {
+                // i.e. replace `"[[NULL_VALUE]]"` with `null`: rather than `"null"`
+                json = json.replace("\"" + entry.getKey() + "\"", "null");
+            } else if (entry.getKey().endsWith("_BOOLEAN]]")) {
+                // i.e. replace `"[[REPLACE_BOOLEAN]]"` with `true` or `false`: rather than `"true"` or `"false"`
+                json = json.replace("\"" + entry.getKey() + "\"", entry.getValue());
+            } else {
+                json = json.replace(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return json;
+    }
+
+    @SneakyThrows
+    public String readJsonFromFile(String fileName)  {
+        Object json;
+
+        if (!fileName.endsWith(".json")) {
+            fileName = String.format("/%s.json", fileName);
+        }
+
+        try (InputStream is = WiremockFixtures.class.getResourceAsStream(fileName)) {
+            json = mapper.readValue(is, Object.class);
+        }
+
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
+    }
+
+    public String readJsonArrayFromFiles(List<String> fileNames)  {
+        return "[" + fileNames.stream()
+            .map(this::readJsonFromFile)
+            .collect(Collectors.joining(",")) + "]";
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/helper/TestScenarioIntegrationHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/helper/TestScenarioIntegrationHelper.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.orgrolemapping.helper;
+
+import org.apache.commons.collections4.MapUtils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class TestScenarioIntegrationHelper {
+
+    public static final DateTimeFormatter DF = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    public static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    // COMMON replace values
+    public static final String IDAM_ID = "[[IDAM_ID]]";
+    public static final String ANY_UUID = "[[ANY_UUID]]";
+    public static final String ANY_DATE_TIME = "[[ANY_DATE_TIME]]";
+    public static final String NOW_DATE_TIME = "[[NOW_DATE_TIME]]";
+
+    public static Map<String, String> cloneAndExpandReplaceMap(Map<String, String> replaceMap) {
+        // add extra values that don't need to match across all the stubs used by test
+        return cloneAndOverrideMap(replaceMap, Map.of(
+            ANY_UUID, UUID.randomUUID().toString(),
+            ANY_DATE_TIME, LocalDateTime.now().minusDays(100).format(DTF),
+            NOW_DATE_TIME, LocalDateTime.now().format(DTF)
+        ));
+    }
+
+    public static Map<String, String> cloneAndOverrideMap(Map<String, String> replaceMap,
+                                                          Map<String, String> overrideMapValues) {
+        Map<String, String> replaceMapClone = replaceMap == null ? new HashMap<>() : new HashMap<>(replaceMap);
+
+        if (MapUtils.isNotEmpty(overrideMapValues)) {
+            replaceMapClone.putAll(overrideMapValues);
+        }
+
+        return replaceMapClone;
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/scheduler/BaseSchedulerTestIntegration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/scheduler/BaseSchedulerTestIntegration.java
@@ -1,0 +1,182 @@
+package uk.gov.hmcts.reform.orgrolemapping.scheduler;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.tomakehurst.wiremock.admin.model.ServeEventQuery;
+import com.github.tomakehurst.wiremock.http.LoggedResponse;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.InjectMocks;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.orgrolemapping.controller.BaseTestIntegration;
+import uk.gov.hmcts.reform.orgrolemapping.controller.utils.WiremockFixtures;
+import uk.gov.hmcts.reform.orgrolemapping.data.AccessTypesEntity;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.OrganisationProfile;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.RestructuredAccessTypes;
+import uk.gov.hmcts.reform.orgrolemapping.helper.JsonHelper;
+import uk.gov.hmcts.reform.orgrolemapping.oidc.IdamRepository;
+import uk.gov.hmcts.reform.orgrolemapping.util.SecurityUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.AUTHORIZATION;
+import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.SERVICE_AUTHORIZATION;
+import static uk.gov.hmcts.reform.orgrolemapping.scheduler.BaseSchedulerTestIntegration.TEST_ENVIRONMENT;
+import static uk.gov.hmcts.reform.orgrolemapping.util.JacksonUtils.MAPPER;
+import static uk.gov.hmcts.reform.orgrolemapping.util.JacksonUtils.writeValueAsPrettyJson;
+
+@Slf4j
+@TestPropertySource(properties = {
+    // turn off service bus
+    "amqp.crd.enabled=false",
+    "amqp.jrd.enabled=false",
+    // set environment ready for flag checks
+    "orm.environment=" + TEST_ENVIRONMENT,
+    "testing.support.enabled=true"
+})
+public class BaseSchedulerTestIntegration extends BaseTestIntegration {
+
+    static final String TEST_ENVIRONMENT = "local";
+
+    static final String DUMMY_AUTH_TOKEN = "DUMMY_AUTH_TOKEN";
+    static final String DUMMY_S2S_TOKEN = "DUMMY_S2S_TOKEN";
+
+    public static final String JURISDICTION_ID_CIVIL = "CIVIL";
+    public static final String JURISDICTION_ID_PUBLICLAW = "PUBLICLAW";
+
+    public static final String SOLICITOR_PROFILE = "SOLICITOR_PROFILE";
+    public static final String OGD_PROFILE = "OGD_PROFILE";
+
+    public static final UUID STUB_ID_CCD_RETRIEVE_ACCESS_TYPES
+        = UUID.fromString("72134798-eba8-4840-b769-6435bd2afb1c");
+
+    protected final JsonHelper jsonHelper = new JsonHelper();
+    protected final WiremockFixtures wiremockFixtures = new WiremockFixtures();
+
+    @InjectMocks
+    private SecurityUtils securityUtils;
+
+    @MockBean
+    private AuthTokenGenerator authTokenGenerator;
+
+    @MockBean
+    private IdamRepository idamRepository;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+
+        // NB: THis is a test for a scheduled job so there will be no SecurityContext loaded from a request
+        SecurityContextHolder.clearContext();
+
+        doReturn(DUMMY_AUTH_TOKEN).when(idamRepository).getUserToken();
+        doReturn(DUMMY_S2S_TOKEN).when(authTokenGenerator).generate();
+
+        wiremockFixtures.resetRequests();
+    }
+
+    @SneakyThrows
+    protected RestructuredAccessTypes extractAccessTypes(AccessTypesEntity accessTypesEntity) {
+        return MAPPER.readValue(accessTypesEntity.getAccessTypes(), new TypeReference<>() {});
+    }
+
+    protected void logObject(String message, Object object) {
+        log.info("{}: {}", message, writeValueAsPrettyJson(object));
+    }
+
+    protected void logOrganisationProfiles(AccessTypesEntity accessTypesEntity) {
+        RestructuredAccessTypes accessTypes = extractAccessTypes(accessTypesEntity);
+
+        if (CollectionUtils.isEmpty(accessTypes.getOrganisationProfiles())) {
+            log.info("No Organisation Profiles found");
+        } else {
+            for (OrganisationProfile orgProfile: accessTypes.getOrganisationProfiles()) {
+                log.info("-----------------------------------------------------");
+                log.info("OrganisationProfileId = {}: {}",
+                    orgProfile.getOrganisationProfileId(),
+                    writeValueAsPrettyJson(orgProfile)
+                );
+                log.info("-----------------------------------------------------");
+            }
+        }
+
+    }
+
+    protected List<ServeEvent> logWiremockPostCalls(UUID stubId) {
+        var allServeEvents = WIRE_MOCK_SERVER.getServeEvents(ServeEventQuery.forStubMapping(stubId)).getServeEvents();
+        log.info("#####################################################");
+
+        int counter = 0;
+        for (ServeEvent event : allServeEvents) {
+            log.info("{}: request number {}:", event.getStubMapping().getName(), counter++);
+
+            logLoggedRequest(event.getRequest());
+            logLoggedResponse(event.getResponse());
+        }
+
+        log.info("#####################################################");
+
+        return allServeEvents;
+    }
+
+    private void logLoggedRequest(LoggedRequest loggedRequest) {
+
+        log.info("-----------------------------------------------------");
+        log.info("Request: {}: '{}'", loggedRequest.getMethod().getName(), loggedRequest.getUrl());
+
+        log.info("   Headers: ");
+        List<String> headersToLog = List.of(
+            AUTHORIZATION,
+            SERVICE_AUTHORIZATION,
+            "Content-Type",
+            "Accept"
+        );
+        for (String header : headersToLog) {
+            log.info("      {}: {}", header, loggedRequest.getHeaders().getHeader(header));
+        }
+
+        log.info("   QueryParameters: {}", loggedRequest.getQueryParams());
+        log.info("   Body: {}", loggedRequest.getBodyAsString());
+        log.info("-----------------------------------------------------");
+    }
+
+    private void logLoggedResponse(LoggedResponse loggedResponse) {
+
+        log.info("-----------------------------------------------------");
+        log.info("Response: ");
+
+        log.info("   Status: {}", loggedResponse.getStatus());
+        log.info("   Body: {}", loggedResponse.getBodyAsString());
+        log.info("-----------------------------------------------------");
+    }
+
+    protected void stubCcdRetrieveAccessTypes(List<String> jurisdictionFileNames) {
+        stubCcdRetrieveAccessTypes(
+            "{ \"jurisdictions\": " + jsonHelper.readJsonArrayFromFiles(jurisdictionFileNames) + " }"
+        );
+    }
+
+    protected void stubCcdRetrieveAccessTypes(String body) {
+        WIRE_MOCK_SERVER.stubFor(post(urlPathMatching("/retrieve-access-types"))
+            .withId(STUB_ID_CCD_RETRIEVE_ACCESS_TYPES)
+            .withName("CCD Retrieve Access Types")
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.OK.value())
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .withBody(body)));
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/scheduler/PrmSchedulerProcess1IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/orgrolemapping/scheduler/PrmSchedulerProcess1IntegrationTest.java
@@ -1,0 +1,317 @@
+package uk.gov.hmcts.reform.orgrolemapping.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.reform.orgrolemapping.data.AccessTypesEntity;
+import uk.gov.hmcts.reform.orgrolemapping.data.AccessTypesRepository;
+import uk.gov.hmcts.reform.orgrolemapping.data.ProfileRefreshQueueRepository;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.OrganisationProfileAccessType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.OrganisationProfileJurisdiction;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.RestructuredAccessTypes;
+import uk.gov.hmcts.reform.orgrolemapping.monitoring.models.EndStatus;
+import uk.gov.hmcts.reform.orgrolemapping.monitoring.models.ProcessMonitorDto;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.AUTHORIZATION;
+import static uk.gov.hmcts.reform.orgrolemapping.apihelper.Constants.SERVICE_AUTHORIZATION;
+
+class PrmSchedulerProcess1IntegrationTest extends BaseSchedulerTestIntegration {
+
+    @Autowired
+    private AccessTypesRepository accessTypesRepository;
+
+    @Autowired
+    private ProfileRefreshQueueRepository profileRefreshQueueRepository;
+
+    @Autowired
+    private Scheduler prmScheduler;
+
+    @Test
+    @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {
+        "classpath:sql/prm/access_types/init_access_types.sql",
+        "classpath:sql/prm/profile_refresh_queue/init_profile_refresh_queue.sql"
+    })
+    void testPrmSchedulerProcess1_emptyCcdResponse() {
+
+        // GIVEN
+        logBeforeStatus();
+        // stub the CCD Def Store call with response for test scenario
+        stubCcdRetrieveAccessTypes(List.of()); // i.e. empty list for empty result
+
+        // WHEN
+        ProcessMonitorDto processMonitorDto = prmScheduler.findAndUpdateCaseDefinitionChanges();
+
+        // THEN
+        verifySingleCallToCcd();
+        logAfterStatus(processMonitorDto);
+
+        // verify that the process monitor reports success
+        assertEquals(EndStatus.SUCCESS, processMonitorDto.getEndStatus());
+
+        // verify that the Access Types are updated (i.e. version 1) and empty
+        assertAndExtractAccessTypesFromDb(1, 0);
+
+        // verify that the ProfileRefreshQueue is empty
+        assertActiveProfileRefreshQueueEntitiesInDb(0);
+    }
+
+    @Test
+    @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {
+        "classpath:sql/prm/access_types/init_access_types.sql",
+        "classpath:sql/prm/profile_refresh_queue/init_profile_refresh_queue.sql"
+    })
+    void testPrmSchedulerProcess1_singleJurisdictionCcdResponse() {
+
+        // GIVEN
+        logBeforeStatus();
+        // stub the CCD Def Store call with response for test scenario
+        stubCcdRetrieveAccessTypes(List.of(
+            "/SchedulerTests/CcdAccessTypes/jurisdiction_civil_scenario_01.json"
+        ));
+
+        // WHEN
+        ProcessMonitorDto processMonitorDto = prmScheduler.findAndUpdateCaseDefinitionChanges();
+
+        // THEN
+        verifySingleCallToCcd();
+        logAfterStatus(processMonitorDto);
+
+        // verify that the process monitor reports success
+        assertEquals(EndStatus.SUCCESS, processMonitorDto.getEndStatus());
+
+        // verify that the Access Types are updated (i.e. version 1) and has 1 organisation profile
+        var accessTypes = assertAndExtractAccessTypesFromDb(1, 1);
+
+        // verify that the OrganisationProfileId is as expected for civil 01
+        assertCivilSolicitorProfile(
+            extractJurisdictionsSolicitorProfileConfig(accessTypes, SOLICITOR_PROFILE, JURISDICTION_ID_CIVIL),
+            "jurisdiction_civil_scenario_01",
+            List.of("CIVIL_SOLICITOR_1")
+        );
+
+        // verify that the ProfileRefreshQueue now has an active entry
+        assertActiveProfileRefreshQueueEntitiesInDb(1);
+
+        // verify that the ProfileRefreshQueue contains the expected OrganisationProfileId
+        assertProfileRefreshQueueEntityInDb("SOLICITOR_PROFILE", 1, true);
+    }
+
+    @Test
+    @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = {
+        "classpath:sql/prm/access_types/init_access_types.sql",
+        "classpath:sql/prm/profile_refresh_queue/init_profile_refresh_queue.sql"
+    })
+    void testPrmSchedulerProcess1_multipleJurisdictionCcdResponse() {
+
+        // GIVEN
+        logBeforeStatus();
+        // stub the CCD Def Store call with response for test scenario
+        stubCcdRetrieveAccessTypes(List.of(
+            "/SchedulerTests/CcdAccessTypes/jurisdiction_civil_scenario_01.json",
+            "/SchedulerTests/CcdAccessTypes/jurisdiction_publiclaw_scenario_01.json"
+        ));
+
+        // WHEN
+        ProcessMonitorDto processMonitorDto = prmScheduler.findAndUpdateCaseDefinitionChanges();
+
+        // THEN
+        verifySingleCallToCcd();
+        logAfterStatus(processMonitorDto);
+
+        // verify that the process monitor reports success
+        assertEquals(EndStatus.SUCCESS, processMonitorDto.getEndStatus());
+
+        // verify that the Access Types are updated (i.e. version 1) and has 1 organisation profile
+        var accessTypes = assertAndExtractAccessTypesFromDb(1, 1);
+
+        // verify that the OrganisationProfileId is as expected for civil 01 & publiclaw 01
+        assertCivilSolicitorProfile(
+            extractJurisdictionsSolicitorProfileConfig(accessTypes, SOLICITOR_PROFILE, JURISDICTION_ID_CIVIL),
+            "jurisdiction_civil_scenario_01",
+            List.of("CIVIL_SOLICITOR_1")
+        );
+        assertPublicLawSolicitorProfile(
+            extractJurisdictionsSolicitorProfileConfig(accessTypes, SOLICITOR_PROFILE, JURISDICTION_ID_PUBLICLAW),
+            "jurisdiction_publiclaw_scenario_01",
+            List.of("PUBLICLAW_SOLICITOR_1")
+        );
+
+        // verify that the ProfileRefreshQueue now has an active entry
+        assertActiveProfileRefreshQueueEntitiesInDb(1);
+
+        // verify that the ProfileRefreshQueue contains the expected OrganisationProfileId
+        assertProfileRefreshQueueEntityInDb(SOLICITOR_PROFILE, 1, true);
+    }
+
+    //#region Assertion Helpers: DB Checks
+
+    private RestructuredAccessTypes assertAndExtractAccessTypesFromDb(int expectedVersion,
+                                                                      int expectedOrganisationProfileCount) {
+        AccessTypesEntity accessTypesEntity = accessTypesRepository.getAccessTypesEntity();
+        assertEquals(expectedVersion, accessTypesRepository.getAccessTypesEntity().getVersion());
+
+        RestructuredAccessTypes accessTypes = extractAccessTypes(accessTypesEntity);
+        assertEquals(expectedOrganisationProfileCount, accessTypes.getOrganisationProfiles().size());
+
+        return accessTypes;
+    }
+
+
+    private void assertActiveProfileRefreshQueueEntitiesInDb(int expectedCount) {
+        var activeProfileEntities = profileRefreshQueueRepository.getActiveProfileEntities();
+        assertEquals(expectedCount, activeProfileEntities.size());
+    }
+
+    private void assertProfileRefreshQueueEntityInDb(String organisationProfileId,
+                                                     int expectedAccessTypesMinVersion,
+                                                     boolean expectedActive) {
+        var profileRefreshQueueEntity = profileRefreshQueueRepository.findById(organisationProfileId);
+        assertTrue(profileRefreshQueueEntity.isPresent());
+        assertEquals(expectedAccessTypesMinVersion, profileRefreshQueueEntity.get().getAccessTypesMinVersion());
+        assertEquals(expectedActive, profileRefreshQueueEntity.get().getActive());
+    }
+
+    //#endregion
+
+
+    //#region Assertion Helpers: AccessTypes.SolicitorProfile
+
+    private void assertCivilSolicitorProfile(OrganisationProfileJurisdiction solicitorProfile,
+                                             String scenarioId,
+                                             List<String> expectedAccessTypeIds) {
+
+        assertEquals(JURISDICTION_ID_CIVIL, solicitorProfile.getJurisdictionId());
+
+        var organisationProfileAccessTypes = extractJurisdictionsOrganisationProfileAccessTypes(solicitorProfile);
+        assertEquals(expectedAccessTypeIds.size(), organisationProfileAccessTypes.size());
+        assertTrue(organisationProfileAccessTypes.keySet().containsAll(expectedAccessTypeIds),
+            "Expected access types not found in organisation profile access types"
+        );
+
+        switch (scenarioId) {
+            case "jurisdiction_civil_scenario_01" -> {
+                var accessType = organisationProfileAccessTypes.get("CIVIL_SOLICITOR_1");
+                assertTrue(accessType.isAccessMandatory());
+                assertTrue(accessType.isAccessDefault());
+
+                var roles = accessType.getRoles().stream().toList();
+                assertEquals(1, roles.size());
+
+                assertEquals("civil_case_type_1", roles.get(0).getCaseTypeId());
+                assertEquals("orgRole1", roles.get(0).getOrganisationalRoleName());
+                assertEquals("groupRole1", roles.get(0).getGroupRoleName());
+                assertEquals("CIVIL:$ORGID$", roles.get(0).getCaseGroupIdTemplate());
+                assertTrue(roles.get(0).isGroupAccessEnabled());
+            }
+
+            case "jurisdiction_civil_scenario_02" -> {
+                // TODO: assert scenario 02
+            }
+
+            default -> fail("Invalid scenario_id: " + scenarioId);
+        }
+
+    }
+
+    private void assertPublicLawSolicitorProfile(OrganisationProfileJurisdiction solicitorProfile,
+                                                 String scenarioId,
+                                                 List<String> expectedAccessTypeIds) {
+
+        assertEquals(JURISDICTION_ID_PUBLICLAW, solicitorProfile.getJurisdictionId());
+
+        var organisationProfileAccessTypes = extractJurisdictionsOrganisationProfileAccessTypes(solicitorProfile);
+        assertEquals(expectedAccessTypeIds.size(), organisationProfileAccessTypes.size());
+        assertTrue(organisationProfileAccessTypes.keySet().containsAll(expectedAccessTypeIds),
+            "Expected access types not found in organisation profile access types"
+        );
+
+        switch (scenarioId) {
+            case "jurisdiction_publiclaw_scenario_01" -> {
+                var accessType = organisationProfileAccessTypes.get("PUBLICLAW_SOLICITOR_1");
+                assertTrue(accessType.isAccessMandatory());
+                assertTrue(accessType.isAccessDefault());
+
+                var roles = accessType.getRoles().stream().toList();
+                assertEquals(1, roles.size());
+
+                assertEquals("publiclaw_case_type_1", roles.get(0).getCaseTypeId());
+                assertEquals("orgRole1", roles.get(0).getOrganisationalRoleName());
+                assertEquals("groupRole1", roles.get(0).getGroupRoleName());
+                assertEquals("PUBLICLAW:$ORGID$", roles.get(0).getCaseGroupIdTemplate());
+                assertTrue(roles.get(0).isGroupAccessEnabled());
+            }
+
+            case "jurisdiction_publiclaw_scenario_02" -> {
+                // TODO: assert scenario 02
+            }
+
+            default -> fail("Invalid scenario_id: " + scenarioId);
+        }
+
+    }
+
+    //#endregion
+
+
+    private OrganisationProfileJurisdiction extractJurisdictionsSolicitorProfileConfig(
+        RestructuredAccessTypes accessTypes,
+        String organisationProfileId,
+        String jurisdiction
+    ) {
+        var organisationProfile = accessTypes.getOrganisationProfiles().stream()
+            .filter(orgProfile -> orgProfile.getOrganisationProfileId().equals(organisationProfileId))
+            .findFirst();
+        assertTrue(organisationProfile.isPresent(), "Organisation Profile not found");
+
+        var organisationProfileJurisdiction = organisationProfile.get().getJurisdictions().stream()
+            .filter(jurisdictionObj -> jurisdictionObj.getJurisdictionId().equals(jurisdiction))
+            .findFirst();
+        assertTrue(organisationProfileJurisdiction.isPresent(), "Organisation Profile Jurisdiction not found");
+
+        return organisationProfileJurisdiction.get();
+    }
+
+    private Map<String, OrganisationProfileAccessType> extractJurisdictionsOrganisationProfileAccessTypes(
+        OrganisationProfileJurisdiction organisationProfileJurisdiction
+    ) {
+        return organisationProfileJurisdiction.getAccessTypes().stream()
+            .collect(Collectors.toMap(OrganisationProfileAccessType::getAccessTypeId, accessType -> accessType));
+    }
+
+
+    private void logAfterStatus(ProcessMonitorDto processMonitorDto) {
+        logObject("ProcessMonitorDto: AFTER", processMonitorDto);
+        logObject("AccessTypes: AFTER", accessTypesRepository.getAccessTypesEntity());
+        logOrganisationProfiles(accessTypesRepository.getAccessTypesEntity());
+        logObject("ProfileRefreshQueueRepository: AFTER", profileRefreshQueueRepository.getActiveProfileEntities());
+    }
+
+    private void logBeforeStatus() {
+        logObject("AccessTypes: BEFORE", accessTypesRepository.getAccessTypesEntity());
+        logOrganisationProfiles(accessTypesRepository.getAccessTypesEntity());
+        logObject("ProfileRefreshQueueRepository: BEFORE", profileRefreshQueueRepository.getActiveProfileEntities());
+    }
+
+
+    private void verifySingleCallToCcd() {
+        var allCallEvents = logWiremockPostCalls(STUB_ID_CCD_RETRIEVE_ACCESS_TYPES);
+        // verify single call
+        assertEquals(1, allCallEvents.size());
+        var event = allCallEvents.get(0);
+        // verify request headers contain Auth tokens
+        var request = event.getRequest();
+        assertTrue(request.getHeader(AUTHORIZATION).endsWith(DUMMY_AUTH_TOKEN));
+        assertTrue(request.getHeader(SERVICE_AUTHORIZATION).endsWith(DUMMY_S2S_TOKEN));
+        // verify response status
+        assertEquals(HttpStatus.OK.value(), event.getResponse().getStatus());
+    }
+
+}

--- a/src/integrationTest/resources/SchedulerTests/CcdAccessTypes/jurisdiction_civil_scenario_01.json
+++ b/src/integrationTest/resources/SchedulerTests/CcdAccessTypes/jurisdiction_civil_scenario_01.json
@@ -1,0 +1,25 @@
+{
+  "jurisdictionId": "CIVIL",
+  "jurisdictionName": "Civil",
+  "accessTypes": [
+    {
+      "organisationProfileId": "SOLICITOR_PROFILE",
+      "accessTypeId": "CIVIL_SOLICITOR_1",
+      "accessMandatory": true,
+      "accessDefault": true,
+      "display": true,
+      "description": "Civil Solicitor 1 description",
+      "hint": "Civil Solicitor 1 hint",
+      "displayOrder": 1,
+      "roles": [
+        {
+          "caseTypeId": "civil_case_type_1",
+          "organisationalRoleName": "orgRole1",
+          "groupRoleName": "groupRole1",
+          "caseGroupIdTemplate": "CIVIL:$ORGID$",
+          "groupAccessEnabled": true
+        }
+      ]
+    }
+  ]
+}

--- a/src/integrationTest/resources/SchedulerTests/CcdAccessTypes/jurisdiction_publiclaw_scenario_01.json
+++ b/src/integrationTest/resources/SchedulerTests/CcdAccessTypes/jurisdiction_publiclaw_scenario_01.json
@@ -1,0 +1,25 @@
+{
+  "jurisdictionId": "PUBLICLAW",
+  "jurisdictionName": "Public Law",
+  "accessTypes": [
+    {
+      "organisationProfileId": "SOLICITOR_PROFILE",
+      "accessTypeId": "PUBLICLAW_SOLICITOR_1",
+      "accessMandatory": true,
+      "accessDefault": true,
+      "display": true,
+      "description": "Public Law Solicitor 1 description",
+      "hint": "Public Law Solicitor 1 hint",
+      "displayOrder": 1,
+      "roles": [
+        {
+          "caseTypeId": "publiclaw_case_type_1",
+          "organisationalRoleName": "orgRole1",
+          "groupRoleName": "groupRole1",
+          "caseGroupIdTemplate": "PUBLICLAW:$ORGID$",
+          "groupAccessEnabled": true
+        }
+      ]
+    }
+  ]
+}

--- a/src/integrationTest/resources/application-itest.yaml
+++ b/src/integrationTest/resources/application-itest.yaml
@@ -14,8 +14,18 @@ idam:
 feign:
   client:
     config:
+      crdclient:
+        url: http://localhost:${wiremock.server.port:8095}
       roleAssignmentApp:
         url: http://localhost:${wiremock.server.port:4096}
+      jrdClient:
+        url: http://localhost:${wiremock.server.port:8091}
+      jbsClient:
+        url: http://localhost:${wiremock.server.port:4097}
+      prdClient:
+        url: http://localhost:${wiremock.server.port:8090}
+      ccdClient:
+        url: http://localhost:${wiremock.server.port:4451}
 
 professional:
   role:

--- a/src/integrationTest/resources/sql/prm/access_types/init_access_types.sql
+++ b/src/integrationTest/resources/sql/prm/access_types/init_access_types.sql
@@ -1,0 +1,4 @@
+DELETE FROM access_types;
+
+INSERT INTO public.access_types (version, access_types)
+VALUES(0, '{}');

--- a/src/integrationTest/resources/sql/prm/profile_refresh_queue/init_profile_refresh_queue.sql
+++ b/src/integrationTest/resources/sql/prm/profile_refresh_queue/init_profile_refresh_queue.sql
@@ -1,0 +1,1 @@
+DELETE FROM profile_refresh_queue;


### PR DESCRIPTION
### Jira link

   [DTSAM-813](https://tools.hmcts.net/jira/browse/DTSAM-813) _"PRM Process 1 Integration Tests need to be expanded to cover ACs"_

### Change description

This PR is a patch to **#2313**, the primary PR for DTSAM-813.   

This PR contains the basic template for the PRM Scheduler Integration Tests, with:
* Stubbed CCD Def Store call based on JSON response
* DB lookups to verify status of AccessTypes & ProfileRefreshQueue values. 
