### PR TITLE
DTSAM-911 Civil 'Lead and Deputy Online Judge'

### DIFF
--- a/src/main/resources/validationrules/civil/civil-judicial-office-holder-mapping.drl
+++ b/src/main/resources/validationrules/civil/civil-judicial-office-holder-mapping.drl
@@ -582,21 +582,21 @@ then
 end;
 
 /*
- * "CIVIL Designated Civil Online Judge" business role mapping to JOH.
+ * "CIVIL Lead and Deputy Online Judge" business role mapping to JOH.
  */
-rule "civil_designated_civil_online_judge_salaried_joh"
+rule "civil_lead_and_deputy_online_judge_salaried_joh"
 when
    $f:  FeatureFlag(status && flagName == FeatureFlagEnum.CIVIL_WA_2_4.getValue())
    $jap: JudicialAccessProfile(appointment != null,
                                appointmentType in ("Salaried", "SPTW"),
                                (endTime == null || endTime.compareTo(ZonedDateTime.now()) >= 0),
-                               (roles != null && roles.contains("Designated Civil Online Judge")),
+                               (roles != null && roles.contains("Lead and Deputy Online Judge")),
                                (validateAuthorisation(authorisations, "AAA6") || validateAuthorisation(authorisations, "AAA7")))
 then
   insert(
       JudicialOfficeHolder.builder()
       .userId($jap.getUserId())
-      .office("CIVIL Designated Civil Online Judge-Salaried")
+      .office("CIVIL Lead and Deputy Online Judge-Salaried")
       .jurisdiction("CIVIL")
       .ticketCodes($jap.getTicketCodes())
       .beginTime($jap.getBeginTime())
@@ -606,5 +606,5 @@ then
       .primaryLocation($jap.getPrimaryLocationId())
       .contractType($jap.getAppointmentType())
       .build());
-      logMsg("Rule : civil_designated_civil_online_judge_salaried_joh");
+      logMsg("Rule : civil_lead_and_deputy_online_judge_salaried_joh");
 end;

--- a/src/main/resources/validationrules/civil/civil-judicial-org-role-mapping.drl
+++ b/src/main/resources/validationrules/civil/civil-judicial-org-role-mapping.drl
@@ -220,13 +220,13 @@ when
                                          "CIVIL Specialist Circuit Judge-Salaried", "CIVIL Senior Circuit Judge-Salaried",
                                          "CIVIL High Court Judge-Salaried", "CIVIL District Judge-Salaried",
                                          "CIVIL Presiding Judge-Salaried", "CIVIL Resident Judge-Salaried",
-                                         "CIVIL Tribunal Judge-Salaried", "CIVIL Designated Civil Online Judge-Salaried" ))
+                                         "CIVIL Tribunal Judge-Salaried", "CIVIL Lead and Deputy Online Judge-Salaried" ))
 then
    Map<String,JsonNode> attribute = new HashMap<>();
    attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Salaried"));
    attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("CIVIL"));
    attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   if (!$joh.getOffice().equalsIgnoreCase("CIVIL Designated Civil Online Judge-Salaried")) {
+   if (!$joh.getOffice().equalsIgnoreCase("CIVIL Lead and Deputy Online Judge-Salaried")) {
      attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
    }
    attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("decision_making_work,applications"));
@@ -414,13 +414,13 @@ rule "v24_civil_leadership_judge_org_role"
 when
   $f:  FeatureFlag(status && flagName == FeatureFlagEnum.CIVIL_WA_2_4.getValue())
   $joh: JudicialOfficeHolder(office in ( "CIVIL Designated Civil Judge-Salaried",
-                                         "CIVIL Designated Civil Online Judge-Salaried" ))
+                                         "CIVIL Lead and Deputy Online Judge-Salaried" ))
 then
    Map<String,JsonNode> attribute = new HashMap<>();
    attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Salaried"));
    attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("CIVIL"));
    attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   if (!$joh.getOffice().equalsIgnoreCase("CIVIL Designated Civil Online Judge-Salaried")) {
+   if (!$joh.getOffice().equalsIgnoreCase("CIVIL Lead and Deputy Online Judge-Salaried")) {
      attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
    }
    attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("decision_making_work,applications," +
@@ -941,7 +941,7 @@ when
                                          "CIVIL Tribunal Judge-Salaried", "CIVIL Tribunal Judge-Fee-Paid",
                                          "CIVIL Employment Judge-Salaried", "CIVIL Employment Judge-Fee-Paid",
                                          "CIVIL Circuit Judge (sitting in retirement)-Fee-Paid",
-                                         "CIVIL Designated Civil Online Judge-Salaried" ))
+                                         "CIVIL Lead and Deputy Online Judge-Salaried" ))
 then
    Map<String,JsonNode> attribute = new HashMap<>();
    if($joh.getOffice().contains("Fee-Paid")) {

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolCivilHearingJudicialRoleMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolCivilHearingJudicialRoleMappingTest.java
@@ -150,7 +150,7 @@ class DroolCivilHearingJudicialRoleMappingTest extends DroolBase {
                 Arguments.of("",
                         "Salaried",
                         false,
-                        List.of("Designated Civil Online Judge"),
+                        List.of("Lead and Deputy Online Judge"),
                         List.of("judge", "leadership-judge", "hmcts-judiciary", "hearing-viewer"))
         );
     }
@@ -229,7 +229,7 @@ class DroolCivilHearingJudicialRoleMappingTest extends DroolBase {
                                    + "intermediate_track_decision_making_work",
                             r.getAttributes().get("workTypes").asText());
                 } else if (r.getRoleName().contains("leadership-judge")) {
-                    if (assignedRoles.contains("Designated Civil Online Judge")) {
+                    if (assignedRoles.contains("Lead and Deputy Online Judge")) {
                         assertNull(r.getAttributes().get("region")); // NB: no region required for this JOH
                     } else {
                         assertEquals("LDN", r.getAttributes().get("region").asText());

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolCivilJudicialRoleMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolCivilJudicialRoleMappingTest.java
@@ -93,7 +93,7 @@ class DroolCivilJudicialRoleMappingTest extends DroolBase {
         "CIVIL High Court Judge-Salaried,'judge,circuit-judge,hmcts-judiciary',5,true",
         "CIVIL High Court Judge-Salaried,'judge,circuit-judge,hmcts-judiciary',11,false",
 
-        "CIVIL Designated Civil Online Judge-Salaried,'judge,leadership-judge,hmcts-judiciary',1,false",
+        "CIVIL Lead and Deputy Online Judge-Salaried,'judge,leadership-judge,hmcts-judiciary',1,false",
     })
     void shouldReturnSalariedRoles(String setOffice, String expectedRoles, String region, boolean expectMultiRegion) {
 
@@ -110,7 +110,7 @@ class DroolCivilJudicialRoleMappingTest extends DroolBase {
                 "judge", "leadership-judge", "task-supervisor", "case-allocator", "circuit-judge", "district-judge"
         );
 
-        if (setOffice.equals("CIVIL Designated Civil Online Judge-Salaried")) {
+        if (setOffice.equals("CIVIL Lead and Deputy Online Judge-Salaried")) {
             rolesThatRequireRegions = List.of(); // NB: no region required for this JOH
         }
 


### PR DESCRIPTION
### Jira link

 * [DTSAM-801](https://tools.hmcts.net/jira/browse/DTSAM-801) _"Add a Civil role mappings for Designated Civil Online Judge - Salaried"_
 * [DTSAM-911](https://tools.hmcts.net/jira/browse/DTSAM-911) _"Adjust Civil JOH mappings for Lead and Deputy Online Judge"_

### Change description

Add Civil mapping for 'Lead and Deputy Online Judge'.

> NB: The flag `civil_wa_2_4` has not been enabled in PROD yet.  Therefore, it is deemed safe to make further adjustments to the rules behind that flag in this PR.  Original ticket & PR was [DTSAM-801](https://tools.hmcts.net/jira/browse/DTSAM-801) & #2287.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - NO