### PR TITLE
DTSAM-816 Enable 'civil_wa_2_4' ORM flag in PROD

### DIFF
--- a/src/main/resources/db/migration/V20250529_801__DTSAM-801_Enable_civil_wa_2_4_Prod.sql
+++ b/src/main/resources/db/migration/V20250529_801__DTSAM-801_Enable_civil_wa_2_4_Prod.sql
@@ -1,0 +1,2 @@
+-- enable civil_wa_2_4 flag in Prod for: DTSAM-801
+update flag_config set status='true' where flag_name='civil_wa_2_4' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### Jira link

 * [DTSAM-801](https://tools.hmcts.net/jira/browse/DTSAM-801) _"Add a Civil role mappings for Designated Civil Online Judge - Salaried"_
 * [DTSAM-911](https://tools.hmcts.net/jira/browse/DTSAM-911) _"Adjust Civil JOH mappings for Lead and Deputy Online Judge"_
 * [DTSAM-816](https://tools.hmcts.net/jira/browse/DTSAM-816) _"Enable 'civil_wa_2_4' ORM flag in PROD"_

### Change description

Added migration script to enable new 'civil_wa_2_4' script in prod

> NB: This is to enable the changes in PR #2287 & #2337.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] Does this PR introduce a breaking change
