### PR TITLE
DTSAM-971 Enable 'civil_wa_2_5' ORM flag in PROD

### DIFF
--- a/src/main/resources/db/migration/V20250721_971__DTSAM-971_Enable_civil_wa_2_5_Prod.sql
+++ b/src/main/resources/db/migration/V20250721_971__DTSAM-971_Enable_civil_wa_2_5_Prod.sql
@@ -1,0 +1,2 @@
+-- enable civil_wa_2_5 flag in Prod for: DTSAM-971 / DTSAM-956
+update flag_config set status='true' where flag_name='civil_wa_2_5' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### Jira link

[DTSAM-971](https://tools.hmcts.net/jira/browse/DTSAM-971) _"Enable 'civil_wa_2_5' ORM flag in PROD"_

### Change description

Enable 'civil_wa_2_5' AM ORM flag in PROD.

> NB: This is to enable the changes in PR #2374.