### PR TITLE
COT-959 Enable 'civil_wa_2_3' AM ORM flag in PROD

### DIFF
--- a/src/main/resources/db/migration/V20250902_959__COT-959_Enable_civil_wa_2_3_Prod.sql
+++ b/src/main/resources/db/migration/V20250902_959__COT-959_Enable_civil_wa_2_3_Prod.sql
@@ -1,0 +1,2 @@
+-- enable civil_wa_2_3 flag in Prod for: COT-959 / COT-958 & COT-1003
+update flag_config set status='true' where flag_name='civil_wa_2_3' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### Jira link

[COT-958](https://tools.hmcts.net/jira/browse/COT-958) _"New Role and Work Type filter for HMCTS Civil Reform - Welsh"_
[COT-1001](https://tools.hmcts.net/jira/browse/COT-1001) _"Update WLU Admin role and Create new WLU Team Leader Role for HMCTS Civil Reform"_
[COT-1003](https://tools.hmcts.net/jira/browse/COT-1003) _"Create new rules for new CIVIL Role - WLU Team Leader"_
[COT-959](https://tools.hmcts.net/jira/browse/COT-959) _"Enable 'civil_wa_2_3' AM ORM flag in PROD"_

### Change description

Enable 'civil_wa_2_3' AM ORM flag in PROD.

> NB: This is to enable the changes in PR #2295 & #2402.