### PR TITLE
DTSAM-545 Enable 'privatelaw_hearing_1_0' AM ORM flag in PROD

### DIFF
--- a/src/main/resources/db/migration/V20250904_545__DTSAM-545_Enable_privatelaw_hearing_1_0_Prod.sql
+++ b/src/main/resources/db/migration/V20250904_545__DTSAM-545_Enable_privatelaw_hearing_1_0_Prod.sql
@@ -1,0 +1,2 @@
+-- enable privatelaw_hearing_1_0 flag in Prod for: DTSAM-545 / DTSAM-517
+update flag_config set status='true' where flag_name='privatelaw_hearing_1_0' and env in ('demo', 'aat', 'perftest', 'ithc', 'prod');


### PR DESCRIPTION
### Jira link

[DTSAM-517](https://tools.hmcts.net/jira/browse/DTSAM-517) _"ORM should not be creating expired Hearing role-assignments for SSCS and PRIVATELAW"_
[DTSAM-545](https://tools.hmcts.net/jira/browse/DTSAM-545) _"Enable 'privatelaw_hearing_1_0' ORM flag in PROD"_

### Change description

Enable 'privatelaw_hearing_1_0' AM ORM flag in PROD.

> NB: This is to enable the PRIVATELAW changes in PR #2100.