### PR TITLE
POFCC-113 FTAs for PCS Caseworker role mappings (Bailiff Admin)

### DIFF
--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/F-019.feature
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/F-019.feature
@@ -261,3 +261,46 @@ Feature: F-019 : Create Possessions Staff Role Assignments
     Then a positive response is received,
     And the response has all other details as expected
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
+
+
+  @S-019.23
+  @FeatureToggle(DB:possessions_wa_1_0=on)
+  Scenario: must successfully create org role mapping for Bailiff Administrator
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to verify caseworker details for Bailiff Administrator (AAA3 PCS)] as in [S-019.23__VerifyCaseworkerDetails],
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments],
+    And a successful call [to publish existing CRD user ids to endpoint] as in [F-019__PushMessageToCRDService],
+    And the request [contains the actorId of the user just published who has Bailiff Administrator role],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Fetch Assignment From Role Assignment Service] operation of [Role Assignment Service],
+    Then a positive response is received,
+    And the response has all other details as expected
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
+
+  @S-019.23a
+  @FeatureToggle(DB:possessions_wa_1_0=on)
+  Scenario: must successfully create org role mapping for Bailiff Administrator + Task Supervisor
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to verify caseworker details for Bailiff Administrator + Task Supervisor (AAA3 PCS)] as in [S-019.23a__VerifyCaseworkerDetails],
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments],
+    And a successful call [to publish existing CRD user ids to endpoint] as in [F-019__PushMessageToCRDService],
+    And the request [contains the actorId of the user just published who has Bailiff Administrator role + Task Supervisor],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Fetch Assignment From Role Assignment Service] operation of [Role Assignment Service],
+    Then a positive response is received,
+    And the response has all other details as expected
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
+
+  @S-019.23b
+  @FeatureToggle(DB:possessions_wa_1_0=on)
+  Scenario: must successfully create org role mapping for Bailiff Administrator + Case allocator
+    Given a user with [an active IDAM profile with full permissions],
+    And a successful call [to verify caseworker details for Bailiff Administrator + Case allocator (AAA3 PCS)] as in [S-019.23b__VerifyCaseworkerDetails],
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments],
+    And a successful call [to publish existing CRD user ids to endpoint] as in [F-019__PushMessageToCRDService],
+    And the request [contains the actorId of the user just published who has Bailiff Administrator role + Case allocator],
+    When a request is prepared with appropriate values,
+    And it is submitted to call the [Fetch Assignment From Role Assignment Service] operation of [Role Assignment Service],
+    Then a positive response is received,
+    And the response has all other details as expected
+    And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23.td.json
@@ -1,0 +1,62 @@
+{
+  "_guid_": "S-019.23",
+  "title": "must successfully create org role mapping for Bailiff Administrator",
+  "_extends_": "F-019_Test_Data_Base",
+
+  "specs": [
+    "contains the actorId of the user just published who has Bailiff Administrator role"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "actorId": "5a9c2e71-3d4f-4b8a-9c1e-6f2d7a8b0c93"
+    }
+  },
+
+  "expectedResponse": {
+    "_extends_": "Common_200_Response",
+    "body": {
+      "roleAssignmentResponse": [
+        {
+          "__ordering__": "UNORDERED",
+          "__elementId__": "roleName"
+        },
+        {
+          "id": "[[ANYTHING_PRESENT]]",
+          "actorIdType": "IDAM",
+          "actorId": "${[scenarioContext][testData][request][pathVariables][actorId]}",
+          "roleType": "ORGANISATION",
+          "roleName": "hmcts-admin",
+          "classification": "PRIVATE",
+          "grantType": "BASIC",
+          "roleCategory": "ADMIN",
+          "readOnly": true,
+          "created": "[[ANYTHING_PRESENT]]",
+          "attributes": {
+            "substantive": "N"
+          }
+        },
+        {
+          "id": "[[ANYTHING_PRESENT]]",
+          "actorIdType": "IDAM",
+          "actorId": "${[scenarioContext][testData][request][pathVariables][actorId]}",
+          "roleType": "ORGANISATION",
+          "roleName": "bailiff-admin",
+          "classification": "PUBLIC",
+          "grantType": "STANDARD",
+          "roleCategory": "ADMIN",
+          "readOnly": false,
+          "created": "[[ANYTHING_PRESENT]]",
+          "attributes": {
+            "substantive": "Y",
+            "primaryLocation": "[[ANYTHING_PRESENT]]",
+            "jurisdiction": "PCS",
+            "workTypes": "enforcement_support,error_management",
+            "region": "1"
+          }
+        }
+      ]
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23.td.json
@@ -51,8 +51,8 @@
             "substantive": "Y",
             "primaryLocation": "[[ANYTHING_PRESENT]]",
             "jurisdiction": "PCS",
-            "workTypes": "enforcement_support,error_management",
-            "region": "1"
+            "region": "[[ANYTHING_PRESENT]]",
+            "workTypes": "enforcement_support,error_management"
           }
         }
       ]

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23__VerifyCaseworkerDetails.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23__VerifyCaseworkerDetails.td.json
@@ -1,0 +1,44 @@
+{
+  "_guid_": "S-019.23__VerifyCaseworkerDetails",
+  "_extends_": "FetchCaseworkersById__PositiveResponse_Base",
+
+  "specs": [
+    "to verify caseworker details for Bailiff Administrator (AAA3 PCS)"
+  ],
+
+  "request": {
+    "body": {
+      "userIds": [
+        "${[scenarioContext][parentContext][testData][request][pathVariables][actorId]}"
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "body": {
+      "arrayInMap": [
+        {
+          "_extends_": "CaseworkerDetails",
+
+          "id": "${[scenarioContext][parentContext][testData][request][pathVariables][actorId]}",
+
+          "case_allocator": "N",
+          "task_supervisor": "N",
+
+          "role": [
+            {
+              "_extends_": "CaseworkerRole_23_Bailiff_Admin"
+            }
+          ],
+
+          "work_area": [
+            {
+              "_extends_": "WorkArea_AAA3_Possessions"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23a.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23a.td.json
@@ -30,7 +30,8 @@
           "attributes": {
             "substantive": "N",
             "primaryLocation": "[[ANYTHING_PRESENT]]",
-            "jurisdiction": "PCS"
+            "jurisdiction": "PCS",
+            "region": "[[ANYTHING_PRESENT]]"
           }
         }
       ]

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23a.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23a.td.json
@@ -1,0 +1,40 @@
+{
+  "_guid_": "S-019.23a",
+  "title": "must successfully create org role mapping for Bailiff Administrator + Task Supervisor",
+  "_extends_": "S-019.23",
+
+  "specs": [
+    "contains the actorId of the user just published who has Bailiff Administrator role + Task Supervisor"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "actorId": "c8f1a6d2-7b3e-4d9a-8f5c-1a2e7b6d4c80"
+    }
+  },
+
+  "expectedResponse": {
+    "body": {
+      "roleAssignmentResponse": [
+        {
+          "id": "[[ANYTHING_PRESENT]]",
+          "actorIdType": "IDAM",
+          "actorId": "${[scenarioContext][testData][request][pathVariables][actorId]}",
+          "roleType": "ORGANISATION",
+          "roleName": "task-supervisor",
+          "classification": "PUBLIC",
+          "grantType": "STANDARD",
+          "roleCategory": "ADMIN",
+          "readOnly": false,
+          "created": "[[ANYTHING_PRESENT]]",
+          "attributes": {
+            "substantive": "N",
+            "primaryLocation": "[[ANYTHING_PRESENT]]",
+            "jurisdiction": "PCS"
+          }
+        }
+      ]
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23a__VerifyCaseworkerDetails.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23a__VerifyCaseworkerDetails.td.json
@@ -1,0 +1,44 @@
+{
+  "_guid_": "S-019.23a__VerifyCaseworkerDetails",
+  "_extends_": "FetchCaseworkersById__PositiveResponse_Base",
+
+  "specs": [
+    "to verify caseworker details for Bailiff Administrator + Task Supervisor (AAA3 PCS)"
+  ],
+
+  "request": {
+    "body": {
+      "userIds": [
+        "${[scenarioContext][parentContext][testData][request][pathVariables][actorId]}"
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "body": {
+      "arrayInMap": [
+        {
+          "_extends_": "CaseworkerDetails",
+
+          "id": "${[scenarioContext][parentContext][testData][request][pathVariables][actorId]}",
+
+          "case_allocator": "N",
+          "task_supervisor": "Y",
+
+          "role": [
+            {
+              "_extends_": "CaseworkerRole_23_Bailiff_Admin"
+            }
+          ],
+
+          "work_area": [
+            {
+              "_extends_": "WorkArea_AAA3_Possessions"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23b.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23b.td.json
@@ -1,0 +1,40 @@
+{
+  "_guid_": "S-019.23b",
+  "title": "must successfully create org role mapping for Bailiff Administrator + Case allocator",
+  "_extends_": "S-019.23",
+
+  "specs": [
+    "contains the actorId of the user just published who has Bailiff Administrator role + Case allocator"
+  ],
+
+  "request": {
+    "pathVariables": {
+      "actorId": "2d7b9c5e-1a3f-4c8d-b6e2-9f0a7c3d5e41"
+    }
+  },
+
+  "expectedResponse": {
+    "body": {
+      "roleAssignmentResponse": [
+        {
+          "id": "[[ANYTHING_PRESENT]]",
+          "actorIdType": "IDAM",
+          "actorId": "${[scenarioContext][testData][request][pathVariables][actorId]}",
+          "roleType": "ORGANISATION",
+          "roleName": "case-allocator",
+          "classification": "PUBLIC",
+          "grantType": "STANDARD",
+          "roleCategory": "ADMIN",
+          "readOnly": false,
+          "created": "[[ANYTHING_PRESENT]]",
+          "attributes": {
+            "substantive": "N",
+            "primaryLocation": "[[ANYTHING_PRESENT]]",
+            "jurisdiction": "PCS"
+          }
+        }
+      ]
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23b.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23b.td.json
@@ -30,7 +30,8 @@
           "attributes": {
             "substantive": "N",
             "primaryLocation": "[[ANYTHING_PRESENT]]",
-            "jurisdiction": "PCS"
+            "jurisdiction": "PCS",
+            "region": "[[ANYTHING_PRESENT]]"
           }
         }
       ]

--- a/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23b__VerifyCaseworkerDetails.td.json
+++ b/src/functionalTest/resources/features/F-019 - Create Possessions Staff Role Assignments/S-019.23b__VerifyCaseworkerDetails.td.json
@@ -1,0 +1,44 @@
+{
+  "_guid_": "S-019.23b__VerifyCaseworkerDetails",
+  "_extends_": "FetchCaseworkersById__PositiveResponse_Base",
+
+  "specs": [
+    "to verify caseworker details for Bailiff Administrator + Case allocator (AAA3 PCS)"
+  ],
+
+  "request": {
+    "body": {
+      "userIds": [
+        "${[scenarioContext][parentContext][testData][request][pathVariables][actorId]}"
+      ]
+    }
+  },
+
+  "expectedResponse": {
+    "body": {
+      "arrayInMap": [
+        {
+          "_extends_": "CaseworkerDetails",
+
+          "id": "${[scenarioContext][parentContext][testData][request][pathVariables][actorId]}",
+
+          "case_allocator": "Y",
+          "task_supervisor": "N",
+
+          "role": [
+            {
+              "_extends_": "CaseworkerRole_23_Bailiff_Admin"
+            }
+          ],
+
+          "work_area": [
+            {
+              "_extends_": "WorkArea_AAA3_Possessions"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+}

--- a/src/functionalTest/resources/features/common/external/ref-data/snippet/caseworker-roles/CaseworkerRole_23_Bailiff_Admin.td.json
+++ b/src/functionalTest/resources/features/common/external/ref-data/snippet/caseworker-roles/CaseworkerRole_23_Bailiff_Admin.td.json
@@ -1,0 +1,7 @@
+{
+  "_guid_": "CaseworkerRole_23_Bailiff_Admin",
+  "_extends_": "CaseworkerRole__Base",
+
+  "role_id": "23",
+  "role": "Bailiff Administrator"
+}

--- a/src/main/resources/validationrules/possessions/possessions-admin-mapping.drl
+++ b/src/main/resources/validationrules/possessions/possessions-admin-mapping.drl
@@ -141,11 +141,11 @@ then
     Map<String,JsonNode> attribute = new HashMap<>();
     attribute.put(Attributes.Name.JURISDICTION, JacksonUtils.convertObjectIntoJsonNode(Jurisdiction.POSSESSIONS.getName()));
     attribute.put(Attributes.Name.PRIMARY_LOCATION, JacksonUtils.convertObjectIntoJsonNode($cap.getPrimaryLocationId()));
-    if($cap.hasValidJobTitle(JobTitle.HEARING_CENTRE_TEAM_LEADER,
-                             JobTitle.HEARING_CENTRE_ADMIN,
-                             JobTitle.BAILIFF_ADMIN)) {
-                attribute.put(Attributes.Name.REGION, JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
-                }
+    if ($cap.hasValidJobTitle(JobTitle.HEARING_CENTRE_TEAM_LEADER,
+                              JobTitle.HEARING_CENTRE_ADMIN,
+                              JobTitle.BAILIFF_ADMIN)) {
+        attribute.put(Attributes.Name.REGION, JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
+    }
 
     insert(
         RoleAssignment.builder()
@@ -183,11 +183,11 @@ then
     Map<String,JsonNode> attribute = new HashMap<>();
     attribute.put(Attributes.Name.JURISDICTION, JacksonUtils.convertObjectIntoJsonNode(Jurisdiction.POSSESSIONS.getName()));
     attribute.put(Attributes.Name.PRIMARY_LOCATION, JacksonUtils.convertObjectIntoJsonNode($cap.getPrimaryLocationId()));
-    if($cap.hasValidJobTitle(JobTitle.HEARING_CENTRE_TEAM_LEADER,
-                             JobTitle.HEARING_CENTRE_ADMIN,
-                             JobTitle.BAILIFF_ADMIN)) {
-            attribute.put(Attributes.Name.REGION, JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
-                }
+    if ($cap.hasValidJobTitle(JobTitle.HEARING_CENTRE_TEAM_LEADER,
+                              JobTitle.HEARING_CENTRE_ADMIN,
+                              JobTitle.BAILIFF_ADMIN)) {
+        attribute.put(Attributes.Name.REGION, JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
+    }
 
     insert(
         RoleAssignment.builder()
@@ -286,6 +286,7 @@ then
     Map<String,JsonNode> attribute = new HashMap<>();
     attribute.put(Attributes.Name.JURISDICTION, JacksonUtils.convertObjectIntoJsonNode(Jurisdiction.POSSESSIONS.getName()));
     attribute.put(Attributes.Name.PRIMARY_LOCATION, JacksonUtils.convertObjectIntoJsonNode($cap.getPrimaryLocationId()));
+    attribute.put(Attributes.Name.REGION, JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
     attribute.put(Attributes.Name.WORK_TYPES, JacksonUtils.convertObjectIntoJsonNode("enforcement_support,error_management"));
 
     insert(
@@ -321,9 +322,9 @@ then
     attribute.put(Attributes.Name.JURISDICTION, JacksonUtils.convertObjectIntoJsonNode(Jurisdiction.POSSESSIONS.getName()));
     attribute.put(Attributes.Name.PRIMARY_LOCATION, JacksonUtils.convertObjectIntoJsonNode($cap.getPrimaryLocationId()));
     attribute.put(Attributes.Name.WORK_TYPES, JacksonUtils.convertObjectIntoJsonNode("access_requests"));
-    if($cap.hasValidJobTitle(JobTitle.HEARING_CENTRE_TEAM_LEADER)) {
-                        attribute.put(Attributes.Name.REGION, JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
-                }
+    if ($cap.hasValidJobTitle(JobTitle.HEARING_CENTRE_TEAM_LEADER)) {
+        attribute.put(Attributes.Name.REGION, JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
+    }
 
     insert(
         RoleAssignment.builder()

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolPossessionsStaffOrgRoleMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolPossessionsStaffOrgRoleMappingTest.java
@@ -221,7 +221,7 @@ class DroolPossessionsStaffOrgRoleMappingTest extends DroolBase {
         Classification.PUBLIC,
         GrantType.STANDARD,
         false,
-        NO_REGION,
+        REGION_LDN,
         PRIMARY_LOCATION_ID,
         WORK_TYPES_BAILIFF
     );


### PR DESCRIPTION
### Jira link

[POFCC-113](https://tools.hmcts.net/jira/browse/POFCC-113) "Additional ORM Functional Tests For Possessions caseworkers"

### Change description

Additional functional Tests for PCS Bailiff Admin role mappings in: 
* #2705

This extends the original FTAs from:
* #2717
 