### PR TITLE
DTSAM-1260 For GA not to syncin DEMO and PERTEST

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -56,7 +56,7 @@ def secrets = [
 ]
 
 // Configure branches to sync with master branch
-def branchesToSync = ['demo', 'ithc', 'perftest']
+def branchesToSync = ['ithc']
 
 // Vars needed for functional and smoke tests run against AKS
 env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"


### PR DESCRIPTION
This is For GA work not to sync on DEMO and PERTEST

### Jira link

https://tools.hmcts.net/jira/browse/DTSAM-1260

### Change description

Switch ORM branch synchronisation off for PerfTest and Demo during GA testing