### PR TITLE
DTSAM-1301 Re-enable sync of Demo and PerfTest branches

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -56,7 +56,7 @@ def secrets = [
 ]
 
 // Configure branches to sync with master branch
-def branchesToSync = ['ithc']
+def branchesToSync = ['demo', 'ithc', 'perftest']
 
 // Vars needed for functional and smoke tests run against AKS
 env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"


### PR DESCRIPTION
### Jira link

[DTSAM-1301](https://tools.hmcts.net/jira/browse/DTSAM-1301) _"GA PRM Deploy to PROD but disabled"_

### Change description

Re-enable the synchronisation of the of **Demo** and **PerfTest** branches when the master pipeline successfully completes.


> NB: This reverts:
> * #2727