### PR TITLE
DTSAM-1314 retire disabled PRIVATELAW rules

### DIFF
--- a/src/main/resources/validationrules/privatelaw/privatelaw-admin-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-admin-mapping.drl
@@ -104,40 +104,6 @@ then
 end;
 
 /*
- * privatelaw admin "case-allocator" Org role mapping.
- * Made obsolete in DTSAM-668 - disabled by PRIVATELAW_WA.1_5 flag.
- * To be removed in DTSAM-671.
- */
-
-rule "privatelaw_case_allocator_admin_org_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_5.getValue())
-  $cap: CaseWorkerAccessProfile(roleId =="3", serviceCode == "ABA5", !suspended,
-                         caseAllocatorFlag == "Y")
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($cap.getPrimaryLocationId()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($cap.getId())
-      .roleCategory(RoleCategory.ADMIN)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("case-allocator")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .authorisations($cap.getSkillCodes())
-      .attributes(attribute)
-      .build());
-      logMsg("Rule : privatelaw_case_allocator_admin_org_role");
-end;
-
-/*
  * privatelaw admin "case-allocator" Org role mapping. v1_5
  */
 

--- a/src/main/resources/validationrules/privatelaw/privatelaw-caseworker-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-caseworker-mapping.drl
@@ -102,39 +102,6 @@ then
 end;
 
 /*
- * privatelaw staff "case-allocator" Org role mapping.
- * Made obsolete in DTSAM-668 - disabled by PRIVATELAW_WA.1_5 flag.
- * To be removed in DTSAM-671.
- */
-
-rule "privatelaw_case_allocator_staff_org_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_5.getValue())
-  $cap: CaseWorkerAccessProfile(roleId == "1", serviceCode == "ABA5",
-                                !suspended, caseAllocatorFlag == "Y")
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($cap.getPrimaryLocationId()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($cap.getRegionId()));
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($cap.getId())
-      .roleCategory(RoleCategory.LEGAL_OPERATIONS)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("case-allocator")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .authorisations($cap.getSkillCodes())
-      .attributes(attribute)
-      .build());
-      logMsg("Rule : privatelaw_case_allocator_staff_org_role");
-end;
-
-/*
  * privatelaw staff "case-allocator" Org role mapping. v1_5
  */
 

--- a/src/main/resources/validationrules/privatelaw/privatelaw-ctsc-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-ctsc-mapping.drl
@@ -136,38 +136,6 @@ end;
 
 /*
  * privatelaw ctsc "case-allocator" Org role mapping. V1.5
- * Made obsolete in DTSAM-668 - disabled by PRIVATELAW_WA.1_5 flag.
- * To be removed in DTSAM-671.
- */
-
-rule "privatelaw_ctsc_case_allocator_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_5.getValue())
-  $cap: CaseWorkerAccessProfile(roleId =="9", serviceCode == "ABA5", !suspended,
-                           caseAllocatorFlag == "Y")
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($cap.getPrimaryLocationId()));
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($cap.getId())
-      .roleCategory(RoleCategory.CTSC)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("case-allocator")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .authorisations($cap.getSkillCodes())
-      .attributes(attribute)
-      .build());
-      logMsg("Rule : privatelaw_ctsc_case_allocator_role");
-end;
-
-/*
- * privatelaw ctsc "case-allocator" Org role mapping. V1.5
  */
 
 rule "privatelaw_ctsc_case_allocator_role_v1_5"

--- a/src/main/resources/validationrules/privatelaw/privatelaw-judicial-office-holder-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-judicial-office-holder-mapping.drl
@@ -80,36 +80,6 @@ then
 end;
 
 /*
- * "PRIVATELAW Deputy District Judge-Fee-Paid" business role business role mapping to JOH.
- * Made obsolete in DTSAM-626 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_deputy_district_judge_fee_paid_joh"
-when
-   $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-   $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-   $jap: JudicialAccessProfile(appointment == "Deputy District Judge- Fee-Paid",
-                               appointmentType == "Fee Paid",
-                               (endTime == null || endTime.compareTo(ZonedDateTime.now()) >= 0),
-                               validateAuthorisation(authorisations, "ABA5"))
-then
-  insert(
-      JudicialOfficeHolder.builder()
-      .userId($jap.getUserId())
-      .office("PRIVATELAW Deputy District Judge-Fee-Paid")
-      .jurisdiction("PRIVATELAW")
-      .ticketCodes($jap.getTicketCodes())
-      .beginTime($jap.getBeginTime())
-      .endTime($jap.getEndTime())
-      .regionId($jap.getRegionId())
-      .baseLocationId($jap.getBaseLocationId())
-      .primaryLocation($jap.getPrimaryLocationId())
-      .contractType($jap.getAppointmentType())
-      .build());
-      logMsg("Rule : privatelaw_deputy_district_judge_fee_paid_joh");
-end;
-
-/*
  * "PRIVATELAW Deputy District Judge-Fee-Paid" business role business role mapping to JOH For v1.6.
  * The creation of the JOH object accommodates for both 'Deputy District Judge-Fee-Paid'
  * and 'Deputy District Judge' appointments. See DTSAM-626.
@@ -137,36 +107,6 @@ then
       .contractType($jap.getAppointmentType())
       .build());
       logMsg("Rule : v1_6_privatelaw_deputy_district_judge_fee_paid_joh");
-end;
-
-/*
- * "PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid" business role business role mapping to JOH.
- * Made obsolete in DTSAM-626 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_deputy_district_judge_sitting_in_retirement_fee_paid_joh"
-when
-   $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-   $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-   $jap: JudicialAccessProfile(appointment == "Deputy District Judge- Sitting in Retirement",
-                               appointmentType == "Fee Paid",
-                               (endTime == null || endTime.compareTo(ZonedDateTime.now()) >= 0),
-                               validateAuthorisation(authorisations, "ABA5"))
-then
-  insert(
-      JudicialOfficeHolder.builder()
-      .userId($jap.getUserId())
-      .office("PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid")
-      .jurisdiction("PRIVATELAW")
-      .ticketCodes($jap.getTicketCodes())
-      .beginTime($jap.getBeginTime())
-      .endTime($jap.getEndTime())
-      .regionId($jap.getRegionId())
-      .baseLocationId($jap.getBaseLocationId())
-      .primaryLocation($jap.getPrimaryLocationId())
-      .contractType($jap.getAppointmentType())
-      .build());
-      logMsg("Rule : privatelaw_deputy_district_judge_sitting_in_retirement_fee_paid_joh");
 end;
 
 /*

--- a/src/main/resources/validationrules/privatelaw/privatelaw-judicial-office-holder-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-judicial-office-holder-mapping.drl
@@ -527,36 +527,6 @@ end;
 /*
  * "Stage 1 mapping from judicial appointments/roles(coming from RD JRD access profiles) to judicial office holder.
  * "Family Judge" business role mapping to JOH.
- * Made obsolete in DTSAM-517 - rule will be disabled when PRIVATELAW_HEARING_1_0 flag is enabled.
- * To be removed in DTSAM-529
- */
-rule "family_judge_joh"
-when
-   $f:  FeatureFlag(status && flagName == FeatureFlagEnum.SSCS_HEARING_1_0.getValue())
-   $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_HEARING_1_0.getValue())
-   $jap: JudicialAccessProfile(appointment !=null && validateAuthorisation(authorisations, "ABA5"))
-then
-  insert(
-      JudicialOfficeHolder.builder()
-      .userId($jap.getUserId())
-      .office("Family Judge")
-      .jurisdiction("PRIVATELAW")
-      .ticketCodes($jap.getTicketCodes())
-      .beginTime($jap.getBeginTime())
-      .endTime($jap.getEndTime())
-      .regionId($jap.getRegionId())
-      .baseLocationId($jap.getBaseLocationId())
-      .primaryLocation($jap.getPrimaryLocationId())
-      .contractType($jap.getAppointmentType())
-      .build());
-  $jap.setStatus("JOH_Mapped");
-  update($jap);
-  logMsg("Rule : family_judge_joh");
-end;
-
-/*
- * "Stage 1 mapping from judicial appointments/roles(coming from RD JRD access profiles) to judicial office holder.
- * "Family Judge" business role mapping to JOH.
  */
 rule "v1_0_family_judge_joh"
 when

--- a/src/main/resources/validationrules/privatelaw/privatelaw-judicial-org-role-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-judicial-org-role-mapping.drl
@@ -18,47 +18,6 @@ import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.FeatureFlagEnum;
 import function uk.gov.hmcts.reform.orgrolemapping.domain.service.RequestMappingService.logMsg;
 
 /*
- * PRIVATELAW "judge" Org role mapping.
- * Made obsolete in DTSAM-853 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_judge_org_role_v13"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_3.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-  $joh: JudicialOfficeHolder(office in ( "PRIVATELAW District Judge-Salaried",
-                                         "PRIVATELAW Presiding Judge-Salaried",
-                                         "PRIVATELAW Resident Judge-Salaried",
-                                         "PRIVATELAW Designated Family Judge-Salaried",
-                                         "PRIVATELAW District Judge (MC)-Salaried",
-                                          "PRIVATELAW Circuit Judge-Salaried",
-                                         "PRIVATELAW High Court Judge-Salaried"))
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Salaried"));
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications"));
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($joh.getBeginTime())
-      .endTime($joh.getEndTime() !=null ? $joh.getEndTime().plusDays(1):null)
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_judge_org_role_v13");
-end;
-
-/*
  * PRIVATELAW "judge" Org role mapping for v1_6.
  */
 rule "v1_6_privatelaw_judge_org_role"
@@ -125,43 +84,6 @@ then
       .authorisations($joh.getTicketCodes())
       .build());
       logMsg("Rule : privatelaw_leadership_judge_org_role");
-end;
-
-/*
- * PRIVATELAW "circuit-judge" Org role mapping.
- * Made obsolete in DTSAM-853 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_circuit_judge_org_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-  $joh: JudicialOfficeHolder(office in ( "PRIVATELAW Circuit Judge-Salaried", "PRIVATELAW High Court Judge-Salaried"))
-
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Salaried"));
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications"));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("circuit-judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($joh.getBeginTime())
-      .endTime($joh.getEndTime() !=null ? $joh.getEndTime().plusDays(1):null)
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_circuit_judge_org_role");
 end;
 
 /*
@@ -291,51 +213,6 @@ then
       .authorisations($joh.getTicketCodes())
       .build());
       logMsg("Rule : privatelaw_specific_access_approver_judiciary_org_role");
-end;
-
-/*
- * PRIVATELAW "fee-paid-judge" Org role mapping.
- * Made obsolete in DTSAM-656 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_fee_paid_judge_org_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-  $joh: JudicialOfficeHolder(office in ("PRIVATELAW Deputy Circuit Judge-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Recorder-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – PRFD-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Deputy High Court Judge-Fee-Paid",
-                                        "PRIVATELAW High Court Judge - Sitting in Retirement-Fee-Paid"))
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Fee-Paid"));
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications"));
-   attribute.put("bookable", JacksonUtils.convertObjectIntoJsonNode("true"));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("fee-paid-judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($joh.getBeginTime())
-      .endTime($joh.getEndTime() !=null ? $joh.getEndTime().plusDays(1):null)
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_fee_paid_judge_org_role");
 end;
 
 /*
@@ -478,46 +355,6 @@ end;
 /*
  * PRIVATELAW "circuit-judge" org role can be created by any existing judicial office holder having
  * "PRIVATELAW Deputy Circuit Judge-Fee-Paid" business role.
- * Made obsolete in DTSAM-853 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_circuit_judge_org_role_for_fee_paid_judge"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-  $joh: JudicialOfficeHolder(office in ("PRIVATELAW Deputy Circuit Judge-Fee-Paid"))
-  $bk: JudicialBooking(userId == $joh.userId)
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($bk.getLocationId() != null ?
-      $bk.getLocationId():$joh.getPrimaryLocation()));
-   attribute.put("baseLocation", JacksonUtils.convertObjectIntoJsonNode($bk.getLocationId()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($bk.getRegionId()));
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Fee-Paid"));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications"));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("circuit-judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($bk.getBeginTime())
-      .endTime($bk.getEndTime())
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_circuit_judge_org_role_for_fee_paid_judge");
-end;
-
-/*
- * PRIVATELAW "circuit-judge" org role can be created by any existing judicial office holder having
- * "PRIVATELAW Deputy Circuit Judge-Fee-Paid" business role.
  * for v1_6
  */
 rule "v1_6_privatelaw_circuit_judge_org_role_for_fee_paid_judge"
@@ -552,54 +389,6 @@ then
       .authorisations($joh.getTicketCodes())
       .build());
       logMsg("Rule : v1_6_privatelaw_circuit_judge_org_role_for_fee_paid_judge");
-end;
-
-/*
- * PRIVATELAW "judge" org role can be created by any existing judicial office holder having
- * "PRIVATELAW Deputy Judge-Fee-Paid, PRIVATELAW Recorder-Fee-Paid,PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid" business role.
- * Made obsolete in DTSAM-656 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_judge_org_role_for_fee_paid_judge_v13"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_3.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-  $joh: JudicialOfficeHolder(office in ("PRIVATELAW Deputy District Judge-Fee-Paid",
-                                        "PRIVATELAW Recorder-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – PRFD-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Deputy High Court Judge-Fee-Paid",
-                                        "PRIVATELAW High Court Judge - Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Deputy Circuit Judge-Fee-Paid"))
-  $bk: JudicialBooking(userId == $joh.userId)
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($bk.getLocationId() != null ?
-   $bk.getLocationId():$joh.getPrimaryLocation()));
-   attribute.put("baseLocation", JacksonUtils.convertObjectIntoJsonNode($bk.getLocationId()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($bk.getRegionId()));
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Fee-Paid"));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications"));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($bk.getBeginTime())
-      .endTime($bk.getEndTime())
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_judge_org_role_for_fee_paid_judge_v13");
 end;
 
 /*
@@ -648,41 +437,6 @@ then
       .authorisations($joh.getTicketCodes())
       .build());
       logMsg("Rule : v1_6_privatelaw_judge_org_role_for_fee_paid_judge");
-end;
-
-/*
- * PRIVATELAW "magistrate" Org role mapping.
- * Made obsolete in DTSAM-853 - rule will be disabled when PRIVATELAW_WA_1_6 is enabled.
- * To be removed in DTSAM-871.
- */
-rule "privatelaw_magistrate_org_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_0.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-  $joh: JudicialOfficeHolder(office in ("PRIVATELAW Magistrates-Voluntary"))
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Voluntary"));
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work, applications"));
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("magistrate")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($joh.getBeginTime())
-      .endTime($joh.getEndTime() !=null ? $joh.getEndTime().plusDays(1):null)
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : privatelaw_magistrate_org_role");
 end;
 
 /*

--- a/src/main/resources/validationrules/privatelaw/privatelaw-judicial-org-role-mapping.drl
+++ b/src/main/resources/validationrules/privatelaw/privatelaw-judicial-org-role-mapping.drl
@@ -216,54 +216,6 @@ then
 end;
 
 /*
- * PRIVATELAW "fee-paid-judge" Org role mapping.
- * Made obsolete in DTSAM-932 - rule will be disabled when PRIVATELAW_WA_1_8 is enabled.
- * To be removed in DTSAM-964.
- */
-rule "v1_6_privatelaw_fee_paid_judge_org_role"
-when
-  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_6.getValue())
-  $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.PRIVATELAW_WA_1_8.getValue())
-  $joh: JudicialOfficeHolder(office in ("PRIVATELAW Deputy Circuit Judge-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge - Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Recorder-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – PRFD-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Fee-Paid",
-                                        "PRIVATELAW Deputy District Judge – (MC)-Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW Deputy High Court Judge-Fee-Paid",
-                                        "PRIVATELAW High Court Judge - Sitting in Retirement-Fee-Paid",
-                                        "PRIVATELAW District Judge (MC) (sitting in retirement)-Fee-Paid",
-                                        "PRIVATELAW District Judge (sitting in retirement)-Fee-Paid"
-                                        ))
-then
-   Map<String,JsonNode> attribute = new HashMap<>();
-   attribute.put("contractType", JacksonUtils.convertObjectIntoJsonNode("Fee-Paid"));
-   attribute.put("jurisdiction", JacksonUtils.convertObjectIntoJsonNode("PRIVATELAW"));
-   attribute.put("primaryLocation", JacksonUtils.convertObjectIntoJsonNode($joh.getPrimaryLocation()));
-   attribute.put("region", JacksonUtils.convertObjectIntoJsonNode($joh.getRegionId()));
-   attribute.put("workTypes", JacksonUtils.convertObjectIntoJsonNode("hearing_work,decision_making_work,applications,routine_work"));
-   attribute.put("bookable", JacksonUtils.convertObjectIntoJsonNode("true"));
-
-  insert(
-      RoleAssignment.builder()
-      .actorIdType(ActorIdType.IDAM)
-      .actorId($joh.getUserId())
-      .roleCategory(RoleCategory.JUDICIAL)
-      .roleType(RoleType.ORGANISATION)
-      .roleName("fee-paid-judge")
-      .grantType(GrantType.STANDARD)
-      .classification(Classification.PUBLIC)
-      .readOnly(false)
-      .beginTime($joh.getBeginTime())
-      .endTime($joh.getEndTime() !=null ? $joh.getEndTime().plusDays(1):null)
-      .attributes(attribute)
-      .authorisations($joh.getTicketCodes())
-      .build());
-      logMsg("Rule : v1_6_privatelaw_fee_paid_judge_org_role");
-end;
-
-/*
  * PRIVATELAW "fee-paid-judge" Org role mapping for v1_8.
  * The fee-paid-judge not able to make booking outside of their CFT region - Private Law
  * see DTSAM-932


### PR DESCRIPTION
### Jira link

[DTSAM-1314](https://tools.hmcts.net/jira/browse/DTSAM-1314) _"Retire existing obsolete Private Law mapping rules in ORM"_
* [DTSAM-529](https://tools.hmcts.net/jira/browse/DTSAM-529) _"Retire rules "sscs_judge_joh" & "family_judge_joh" made obsolete in DTSAM-517"_
* [DTSAM-671](https://tools.hmcts.net/jira/browse/DTSAM-671) _"Retire obsolete PRL ORM case_allocator caseworker rules after DTSAM-668 go live"_
* [DTSAM-871](https://tools.hmcts.net/jira/browse/DTSAM-871) _"Retire ORM rules made obsolete in DTSAM-626, DTSAM-656 & DTSAM-853"_
* [DTSAM-964](https://tools.hmcts.net/jira/browse/DTSAM-964) _"Retire ORM rules made obsolete in DTSAM-932 & DTSAM-960"_

### Change description

Retire obsolete PRIVATELAW rules that are now disabled after their controlling flag has gone live:

| Ticket  | Flag | Change PR | Go-Live PR |
| ------- | ---- | ----------- | ----------- |
| [DTSAM-529](https://tools.hmcts.net/jira/browse/DTSAM-529) (PRL part) | privatelaw_hearing_1_0 | #2100 | #2460 |
| [DTSAM-671](https://tools.hmcts.net/jira/browse/DTSAM-671) | privatelaw_wa_1_5 | #2220 | #2272 |
| [DTSAM-871](https://tools.hmcts.net/jira/browse/DTSAM-871) | privatelaw_wa_1_6 | #2327 | #2370 |
| [DTSAM-964](https://tools.hmcts.net/jira/browse/DTSAM-964) | privatelaw_wa_1_8 | #2373 | #2385 |

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change - **NO**