### PR TITLE
DTSAM-1333 iac_wa_1_8 - new IAC work types for CTSC role

### DIFF
--- a/src/functionalTest/resources/features/F-001 - Create IA Staff Role Assignments/F-001.feature
+++ b/src/functionalTest/resources/features/F-001 - Create IA Staff Role Assignments/F-001.feature
@@ -411,7 +411,7 @@ Feature: F-001 : Create Role Assignments for Caseworker Users
      And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
 
   @S-001.09
-  @FeatureToggle(DB:iac_wa_1_5=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
+  @FeatureToggle(DB:iac_wa_1_8=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC team leader
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to verify caseworker details for CTSC team leader (BFA1 IA)] as in [S-001.09__VerifyCaseworkerDetails],
@@ -425,7 +425,7 @@ Feature: F-001 : Create Role Assignments for Caseworker Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
 
   @S-001.09a
-  @FeatureToggle(DB:iac_wa_1_5=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
+  @FeatureToggle(DB:iac_wa_1_8=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC team leader + Task Supervisor
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to verify caseworker details for CTSC team leader + Task Supervisor (BFA1 IA)] as in [S-001.09a__VerifyCaseworkerDetails],
@@ -439,7 +439,7 @@ Feature: F-001 : Create Role Assignments for Caseworker Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
 
   @S-001.09b
-  @FeatureToggle(DB:iac_wa_1_5=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
+  @FeatureToggle(DB:iac_wa_1_8=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC team leader + Case allocator
      Given a user with [an active IDAM profile with full permissions],
      And a successful call [to verify caseworker details for CTSC team leader + Case allocator (BFA1 IA)] as in [S-001.09b__VerifyCaseworkerDetails],
@@ -453,7 +453,7 @@ Feature: F-001 : Create Role Assignments for Caseworker Users
      And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
 
   @S-001.10
-  @FeatureToggle(DB:iac_wa_1_5=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
+  @FeatureToggle(DB:iac_wa_1_8=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC Administrator
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to verify caseworker details for CTSC Administrator (BFA1 IA)] as in [S-001.10__VerifyCaseworkerDetails],
@@ -467,7 +467,7 @@ Feature: F-001 : Create Role Assignments for Caseworker Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
 
   @S-001.10a
-  @FeatureToggle(DB:iac_wa_1_5=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
+  @FeatureToggle(DB:iac_wa_1_8=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC Administrator + Task Supervisor
     Given a user with [an active IDAM profile with full permissions],
     And a successful call [to verify caseworker details for CTSC Administrator + Task Supervisor (BFA1 IA)] as in [S-001.10a__VerifyCaseworkerDetails],
@@ -481,7 +481,7 @@ Feature: F-001 : Create Role Assignments for Caseworker Users
     And a successful call [to delete existing role assignments corresponding to the test actorId] as in [DeleteDataForRoleAssignments].
 
   @S-001.10b
-  @FeatureToggle(DB:iac_wa_1_5=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
+  @FeatureToggle(DB:iac_wa_1_8=on) @FeatureToggle(EV:CASEWORKER_FTA_ENABLED=on)
   Scenario: must successfully create org role mapping for CTSC Administrator + Case allocator
      Given a user with [an active IDAM profile with full permissions],
      And a successful call [to verify caseworker details for CTSC Administrator + Case allocator (BFA1 IA)] as in [S-001.10b__VerifyCaseworkerDetails],

--- a/src/functionalTest/resources/features/F-001 - Create IA Staff Role Assignments/S-001.09.td.json
+++ b/src/functionalTest/resources/features/F-001 - Create IA Staff Role Assignments/S-001.09.td.json
@@ -52,7 +52,7 @@
             "substantive": "Y",
             "primaryLocation": "[[ANYTHING_PRESENT]]",
             "jurisdiction": "IA",
-            "workTypes" : "hearing_work, upper_tribunal, routine_work, stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work"
+            "workTypes" : "hearing_work, upper_tribunal, routine_work, stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work, queries, queries_stf"
           }
         },
         {

--- a/src/functionalTest/resources/features/F-001 - Create IA Staff Role Assignments/S-001.10.td.json
+++ b/src/functionalTest/resources/features/F-001 - Create IA Staff Role Assignments/S-001.10.td.json
@@ -52,7 +52,7 @@
             "substantive": "Y",
             "primaryLocation": "[[ANYTHING_PRESENT]]",
             "jurisdiction": "IA",
-            "workTypes" : "hearing_work, upper_tribunal, routine_work, stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work"
+            "workTypes" : "hearing_work, upper_tribunal, routine_work, stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work, queries, queries_stf"
           }
         },
         {

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/FeatureFlagEnum.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/FeatureFlagEnum.java
@@ -21,6 +21,7 @@ public enum FeatureFlagEnum {
     IAC_WA_1_5("iac_wa_1_5"),
     IAC_WA_1_6("iac_wa_1_6"),
     IAC_WA_1_7("iac_wa_1_7"),
+    IAC_WA_1_8("iac_wa_1_8"),
     CIVIL_WA_1_1("civil_wa_1_1"),
     PRIVATELAW_WA_1_1("privatelaw_wa_1_1"),
     EMPLOYMENT_WA_1_0("employment_wa_1_0"),

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/WorkType.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/WorkType.java
@@ -26,7 +26,9 @@ public enum WorkType {
     STF_24W_UPPER_TRIBUNAL("stf_24w_upper_tribunal"),
     STOPPED_APPLICATIONS("stopped_applications"),
     UPPER_TRIBUNAL("upper_tribunal"),
-    WELSH_TRANSLATION_WORK("welsh_translation_work");
+    WELSH_TRANSLATION_WORK("welsh_translation_work"),
+    QUERIES("queries"),
+    QUERIES_STF("queries_stf");
 
     private final String value;
 

--- a/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/WorkType.java
+++ b/src/main/java/uk/gov/hmcts/reform/orgrolemapping/domain/model/enums/WorkType.java
@@ -15,6 +15,8 @@ public enum WorkType {
     POST_HEARING("post_hearing"),
     PRE_HEARING("pre_hearing"),
     PRIORITY("priority"),
+    QUERIES("queries"),
+    QUERIES_STF("queries_stf"),
     QUERY_WORK("query_work"),
     REVIEW_CASE("review_case"),
     ROUTINE_WORK("routine_work"),
@@ -26,9 +28,7 @@ public enum WorkType {
     STF_24W_UPPER_TRIBUNAL("stf_24w_upper_tribunal"),
     STOPPED_APPLICATIONS("stopped_applications"),
     UPPER_TRIBUNAL("upper_tribunal"),
-    WELSH_TRANSLATION_WORK("welsh_translation_work"),
-    QUERIES("queries"),
-    QUERIES_STF("queries_stf");
+    WELSH_TRANSLATION_WORK("welsh_translation_work");
 
     private final String value;
 

--- a/src/main/resources/db/migration/V20260629_1333__DTSAM-1333_IAC_WA_1_8_base_flag_addition.sql
+++ b/src/main/resources/db/migration/V20260629_1333__DTSAM-1333_IAC_WA_1_8_base_flag_addition.sql
@@ -1,0 +1,8 @@
+-- DTSAM-1333: insert iac_wa_1_8 base flag into flag_config table
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('iac_wa_1_8', 'local', 'iac', 'true');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('iac_wa_1_8', 'pr', 'iac', 'true');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('iac_wa_1_8', 'aat', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('iac_wa_1_8', 'demo', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('iac_wa_1_8', 'perftest', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('iac_wa_1_8', 'ithc', 'iac', 'false');
+INSERT INTO flag_config (flag_name, env, service_name, status) VALUES ('iac_wa_1_8', 'prod', 'iac', 'false');

--- a/src/main/resources/validationrules/iac/iac-ctsc-mapping.drl
+++ b/src/main/resources/validationrules/iac/iac-ctsc-mapping.drl
@@ -1,10 +1,16 @@
 package validationrules.iac;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.RoleAssignment;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.constants.RoleAssignmentConstants.Attributes;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.constants.RoleAssignmentConstants.RoleName;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.ActorIdType;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.RoleCategory;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.RoleType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.WorkType;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.Classification;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.crd.JobTitle;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.GrantType;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.Jurisdiction;
+import uk.gov.hmcts.reform.orgrolemapping.domain.model.enums.WorkType;
 import uk.gov.hmcts.reform.orgrolemapping.domain.model.CaseWorkerAccessProfile;
 import java.util.ArrayList;
 import  uk.gov.hmcts.reform.orgrolemapping.util.JacksonUtils;
@@ -49,11 +55,14 @@ end;
 
 /*
  * IAC ctsc "ctsc" Org role mapping for 1.5 .
+ * Made obsolete in DTSAM-1333 - rule will be disabled when iac_wa_1_8 is enabled.
+ * To be removed in DTSAM-1338.
  */
 
 rule "v_1_5_iac_ctsc_caseworker"
 when
    $f:  FeatureFlag(status && flagName == FeatureFlagEnum.IAC_WA_1_5.getValue())
+   $f2: FeatureFlag(status == false && flagName == FeatureFlagEnum.IAC_WA_1_8.getValue())
   $up: CaseWorkerAccessProfile(roleId in ("9","10"), serviceCode == "BFA1", !suspended)
 then
    Map<String,JsonNode> attribute = new HashMap<>();
@@ -74,6 +83,47 @@ then
       .authorisations($up.getSkillCodes())
       .build());
       logMsg("Rule : v_1_5_iac_ctsc_caseworker");
+end;
+
+/*
+ * PROBATE ctsc "ctsc" Org role mapping for v1_8.
+ */
+
+rule "v1_8_probate_ctsc"
+when
+  $f:  FeatureFlag(status && flagName == FeatureFlagEnum.IAC_WA_1_8.getValue())
+  $up: CaseWorkerAccessProfile(hasValidJobTitle(JobTitle.CTSC_TEAM_LEADER, JobTitle.CTSC_ADMIN),
+                               hasValidServiceCode(Jurisdiction.IAC), !suspended)
+then
+
+   Map<String,JsonNode> attribute = new HashMap<>();
+   attribute.put(Attributes.Name.JURISDICTION, JacksonUtils.convertObjectIntoJsonNode(Jurisdiction.IAC.getName()));
+   attribute.put(Attributes.Name.PRIMARY_LOCATION, JacksonUtils.convertObjectIntoJsonNode($up.getPrimaryLocationId()));
+   attribute.put(Attributes.Name.WORK_TYPES,
+                 JacksonUtils.convertObjectIntoJsonNode(WorkType.joinValues(
+                                                            WorkType.HEARING_WORK,
+                                                            WorkType.UPPER_TRIBUNAL,
+                                                            WorkType.ROUTINE_WORK,
+                                                            WorkType.STF_24W_HEARING_WORK,
+                                                            WorkType.STF_24W_UPPER_TRIBUNAL,
+                                                            WorkType.STF_24W_ROUTINE_WORK,
+                                                            WorkType.QUERIES,
+                                                            WorkType.QUERIES_STF)));
+  insert(
+
+      RoleAssignment.builder()
+        .actorIdType(ActorIdType.IDAM)
+        .actorId($up.getId())
+        .roleCategory(RoleCategory.CTSC)
+        .roleType(RoleType.ORGANISATION)
+        .roleName(RoleName.CTSC)
+        .grantType(GrantType.STANDARD)
+        .classification(Classification.PUBLIC)
+        .readOnly(false)
+        .attributes(attribute)
+        .authorisations($up.getSkillCodes())
+        .build());
+      logMsg("Rule : v1_8_probate_ctsc");
 end;
 
 rule "iac_hmcts_ctsc_caseworker_v11"

--- a/src/main/resources/validationrules/iac/iac-ctsc-mapping.drl
+++ b/src/main/resources/validationrules/iac/iac-ctsc-mapping.drl
@@ -89,7 +89,7 @@ end;
  * PROBATE ctsc "ctsc" Org role mapping for v1_8.
  */
 
-rule "v1_8_probate_ctsc"
+rule "v1_8_iac_ctsc_caseworker"
 when
   $f:  FeatureFlag(status && flagName == FeatureFlagEnum.IAC_WA_1_8.getValue())
   $up: CaseWorkerAccessProfile(hasValidJobTitle(JobTitle.CTSC_TEAM_LEADER, JobTitle.CTSC_ADMIN),
@@ -123,7 +123,7 @@ then
         .attributes(attribute)
         .authorisations($up.getSkillCodes())
         .build());
-      logMsg("Rule : v1_8_probate_ctsc");
+      logMsg("Rule : v1_8_iac_ctsc_caseworker");
 end;
 
 rule "iac_hmcts_ctsc_caseworker_v11"

--- a/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolIacStaffOrgRoleMappingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/orgrolemapping/domain/service/DroolIacStaffOrgRoleMappingTest.java
@@ -40,7 +40,7 @@ class DroolIacStaffOrgRoleMappingTest extends DroolBase {
         expectedRoleNameWorkTypesMap.put("national-business-centre", "hearing_work, upper_tribunal, routine_work, "
                 + "stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work");
         expectedRoleNameWorkTypesMap.put("ctsc", "hearing_work, upper_tribunal, routine_work, "
-                + "stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work");
+                + "stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work, queries, queries_stf");
         expectedRoleNameWorkTypesMap.put("ctsc-team-leader", "hearing_work, upper_tribunal, routine_work, "
                 + "stf_24w_hearing_work, stf_24w_upper_tribunal, stf_24w_routine_work");
         expectedRoleNameWorkTypesMap.put("senior-tribunal-caseworker", "hearing_work, routine_work, "


### PR DESCRIPTION
### Jira link

[DTSAM-1333](https://tools.hmcts.net/jira/browse/DTSAM-1333) _"iac_wa_1_8 - Add new work types for CTSC Administrator and CTSC Team Leader"_

### Change description

iac_wa_1_8 - Add new work types for CTSC Administrator and CTSC Team Leader

### Testing done

Flag Off functional tests are in:
 * #2803

